### PR TITLE
Relation Algebra instance for decidable relations & sfrel refactoring 

### DIFF
--- a/coq-event-struct.opam
+++ b/coq-event-struct.opam
@@ -21,14 +21,17 @@ depends: [
   "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | (= "dev")}
-  "coq-equations"
-  "coq-relation-algebra" {(>= "1.7.4")}
+  # "coq-relation-algebra" {(>= "1.7.4")}
+  "coq-relation-algebra" {(= "dev")}
   "coq-monae" {(>= "0.2.2") | (= "dev")}
+  "coq-equations"
+]
+pin-depends: [
+  [ "coq-relation-algebra.dev" "git+https://github.com/eupp/relation-algebra#monoid-decoupling"]
 ]
 conflicts: [
   "coq-equations" {(= "dev+HoTT")}
 ]
-
 tags: [
   "keyword:concurrency"
   "keyword:event structures"

--- a/coq-event-struct.opam
+++ b/coq-event-struct.opam
@@ -21,14 +21,14 @@ depends: [
   "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | (= "dev")}
-  # "coq-relation-algebra" {(>= "1.7.4")}
-  "coq-relation-algebra" {(= "dev")}
+  "coq-relation-algebra" {(>= "1.7.4")}
+  # "coq-relation-algebra" {(= "dev")}
   "coq-monae" {(>= "0.2.2") | (= "dev")}
   "coq-equations"
 ]
-pin-depends: [
-  [ "coq-relation-algebra.dev" "git+https://github.com/eupp/relation-algebra#monoid-decoupling"]
-]
+# pin-depends: [
+#   [ "coq-relation-algebra.dev" "git+https://github.com/eupp/relation-algebra#monoid-decoupling"]
+# ]
 conflicts: [
   "coq-equations" {(= "dev+HoTT")}
 ]

--- a/eventstructure.v
+++ b/eventstructure.v
@@ -294,65 +294,25 @@ Proof. exact: fica_ge. Qed.
 (* Causality relation *)
 Definition ca : rel E := (rt_closure fica_gt : {dhrel E & E})°.
 
-Lemma yewq {T : eqType} (r1 r2 : {dhrel T & T}) : 
-  r1 ≡ r2 -> (r1 : hrel T T) ≡ r2. 
-Proof. by move=> H x y /=; rewrite (H x y). Qed.
-
-Lemma hh {T : eqType} (r : {dhrel T & T}) : 
-  (r° : hrel T T) ≡ (r : hrel T T)°. 
-Proof. done. Qed.
-
-Lemma hhqq {T : eqType} (r : {dhrel T & T}) : 
-  (r^? : hrel T T) ≡ (r : hrel T T)^?. 
-Proof. 
-  move=> x y /=. rewrite /dhrel_one. 
-  symmetry. apply /(rwP predU1P).
-Qed.
-
-Lemma hhww {T : eqType} (r : {dhrel T & T}) : 
-  (r \ 1 : hrel T T) ≡ (r : hrel T T) \ 1. 
-Proof. 
-  move=> x y /=. rewrite /dhrel_one. 
-  rewrite and_comm andbC.
-  symmetry. apply /(rwP predD1P).
-Qed.
-
-Lemma uu {T : eqType} (R : hrel T T) (r : {dhrel T & T}) : 
-  R ≡ r -> forall x y, reflect (R x y) (r x y). 
-Proof. 
-  move=> H x y; apply: equivP; first by exact: idP. 
-  symmetry; apply H. 
-Qed.
-
-Lemma qq {T : eqType} (R : hrel T T) (r : {dhrel T & T}) : 
-  (forall x y, reflect (R x y) (r x y)) -> R ≡ r. 
-Proof. by move=> H x y; apply rwP. Qed.
-
-Lemma ss {T : eqType} (r1 r2 : {dhrel T & T}) : 
-  r1 ≡ r2 -> (r1 : hrel T T) ≡ r2. 
-Proof. move=> H. apply qq. move=> x y. rewrite (H x y). exact: idP. Qed.
-
 Lemma closureP e1 e2 :
   reflect (clos_refl_trans _ ica e1 e2) (ca e1 e2).
 Proof. 
-  rewrite /ca /ica. apply uu.
+  rewrite /ca /ica. apply weq_reflect.
   rewrite !clos_refl_trans_hrel_str.
-  rewrite hh hh -kleene.cnvstr.
+  rewrite rel_cnv_m rel_cnv_m -kleene.cnvstr.
   apply cnv_weq_iff.
   rewrite str_itr itr_qmk.
-
-  rewrite -cup_sub_one; last first.
-  (* (* TODO: make a lemma *) *)
-  - move=> x y /=. split; first done.
-    case: (boolP (x == y)) => /eqP; firstorder.
-
-  etransitivity. 
-  - rewrite -hhww -hhqq yewq; last by rewrite -strictify_weq.
-    rewrite hhqq; done.
-
+  rewrite -qmk_sub_one; last first.
+  (* TODO: make a lemma? *)
+  - rewrite -rel_top_m -rel_one_m -rel_neg_m -rel_cup_m.
+    apply /rel_weq_m/dhrel_eq_dec.
+  rewrite kleene.itr_weq; last first.
+  - rewrite -rel_one_m -rel_sub_m -rel_cup_m.
+    by apply /rel_weq_m; rewrite -strictify_weq.
+  rewrite rel_qmk_m.
   rewrite -itr_qmk -str_itr.
   rewrite -clos_refl_trans_hrel_str.
-  apply qq. apply /rt_closureP.
+  apply /reflect_weq/rt_closureP.
 Qed.
 
 Lemma closure_n1P e1 e2 :

--- a/eventstructure.v
+++ b/eventstructure.v
@@ -286,22 +286,26 @@ Qed.
 (* ************************************************************************* *)
 
 (* Immediate causality relation *)
-Definition ica : rel E := (@sfrel _ monad.id_ndmorph E fica : {dhrel E & E})°.
+Definition ica : {dhrel E & E} := 
+  (@sfrel _ monad.id_ndmorph E fica : {dhrel E & E})°.
+
+Lemma icaE : ica =2 [rel e1 e2 | e1 \in fica e2].
+Proof. by []. Qed.
 
 Lemma ica_le e1 e2 : ica e1 e2 -> e1 <= e2.
 Proof. exact: fica_ge. Qed.
 
 (* Causality relation *)
-Definition ca : rel E := (rt_closure fica_gt : {dhrel E & E})°.
+Definition ca : rel E := (rt_closure fica_gt)°.
 
 Lemma closureP e1 e2 :
   reflect (clos_refl_trans _ ica e1 e2) (ca e1 e2).
 Proof. 
   rewrite /ca /ica. apply weq_reflect.
   rewrite !clos_refl_trans_hrel_str.
-  rewrite rel_cnv_m rel_cnv_m -kleene.cnvstr.
+  rewrite rel_cnv_m -kleene.cnvstr.
   apply cnv_weq_iff.
-  rewrite str_itr itr_qmk.
+  rewrite cnv_invol str_itr itr_qmk.
   rewrite -qmk_sub_one; last first.
   (* TODO: make a lemma? *)
   - rewrite -rel_top_m -rel_one_m -rel_neg_m -rel_cup_m.
@@ -329,16 +333,13 @@ Proof. by move=> x y H; apply /closureP /rt_step. Qed.
 (* Proof. exact: rt_closure_subrel. Qed. *)
 
 Lemma ica_fpred {e}: ica (fpred e) e.
-Proof. by rewrite /ica /= /dhrel_cnv /= /sfrel /= /fica !inE eqxx. Qed.
+Proof. by rewrite icaE /= !inE eqxx. Qed.
 
 Lemma ica_notdom e1 e2:
   e2 \notin dom ->
   ica e1 e2 ->
   e1 == e2.
-Proof. 
-  move=> ?; rewrite /ica /= /dhrel_cnv/sfrel /=. 
-  by rewrite fica_dom // !inE orbb. 
-Qed.
+Proof. by move=> ?; rewrite icaE /= fica_dom // !inE orbb. Qed.
 
 Lemma ca_refl {e} : ca e e.
 Proof. exact: rt_closure_refl. Qed.
@@ -568,7 +569,7 @@ Proof.
   move=> /cfP[x [y [[]]]]; case: (eqVneq x m)=> [-> _|].
   - by move=> /ca_le L /and4P[_ /eqP<- _ /(le_lt_trans L)]; rewrite ltxx.
   move/ca_step_last=> /[apply] [[z /and3P[/[swap]]]].
-  rewrite /ica /= /dhrel_cnv /= /sfrel /fica /= !inE=> /pred2P[]-> Cx L.
+  rewrite icaE /= !inE=> /pred2P[]-> Cx L.
   - move=> /ca_fpredr Cy /icf_cf/cf_consist2/(_ Cx Cy).
     rewrite cf_sym rff_consist //=. 
     apply/eqP=> fE; by rewrite fE ltxx in L.

--- a/relations.v
+++ b/relations.v
@@ -52,7 +52,7 @@ Local Notation List := ModelNondet.list.
 
 (* TODO: rename to `mrel` and move to `monad.v` ? *)
 Definition sfrel {M : nondetMonad} {η : M ≈> List}
-  {T : eqType} (f : T -> M T) : rel T :=
+  {T : eqType} (f : T -> M T) : {dhrel T & T} :=
     [rel a b | b \in η T (f a)].
 
 Section Strictify.
@@ -113,11 +113,11 @@ Definition wsuffix (x : T) : M T :=
   Alt (Ret x) (suffix x).
 
 (* decidable transitive closure *)
-Definition t_closure : rel T := 
+Definition t_closure : {dhrel T & T} := 
   fun x y => y \in η T (suffix x).
 
 (* decidable reflexive-transitive closure *)
-Definition rt_closure : rel T := 
+Definition rt_closure : {dhrel T & T} := 
   fun x y => y \in η T (wsuffix x).
   
 (* ************************************************************************** *)
@@ -179,7 +179,7 @@ Proof.
   by apply predU1P.
 Qed.
 
-Lemma rt_closureE : rt_closure ≡ (t_closure : {dhrel T & T})^?.
+Lemma rt_closureE : rt_closure ≡ t_closure^?.
 Proof. 
   move=> x y /=; rewrite /rt_closure /t_closure /wsuffix. 
   rewrite alt_morph /Alt /= /monae_lib.curry /= mem_cat /dhrel_one.

--- a/transitionsystem.v
+++ b/transitionsystem.v
@@ -196,8 +196,7 @@ Lemma ica_add_eventE e1 e2 :
     (pred == e1) || (write == e1)
   else ica es e1 e2.
 Proof.
-  (* TODO: refactor rewriting of /ica, here and in similar contexts *)
-  rewrite /ica /= /dhrel_cnv /sfrel /fica /= frf_add_eventE fpred_add_eventE.
+  rewrite icaE /= /fica frf_add_eventE fpred_add_eventE.
   by case: ifP=> ?; rewrite ?(andTb, andFb) ?orbF // ?inE eq_sym orbC eq_sym.
 Qed.
 
@@ -241,8 +240,7 @@ Proof.
   rewrite -cf_add_eventE //.
   apply/negP=> /eqP Ef.
   have /ica_fresh /eqP /(negP N) //: ica es fresh_id e1.
-  (* TODO: refactor rewriting of /ica, here and in similar contexts *)
-  by rewrite /ica /= /dhrel_cnv /sfrel /fica /= ?inE -Ef eq_refl.
+  by rewrite icaE /= ?inE -Ef eq_refl.
 Qed.
 
 Lemma consist_add_new_event: dom_consistency add_new_event.

--- a/transitionsystem.v
+++ b/transitionsystem.v
@@ -1,6 +1,6 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice seq path.
 From mathcomp Require Import order finmap fintype.
-From event_struct Require Import utilities eventstructure ident.
+From event_struct Require Import utilities relations eventstructure ident.
 
 (******************************************************************************)
 (* Here we want to make function that by event and event structure creates a  *)
@@ -196,7 +196,8 @@ Lemma ica_add_eventE e1 e2 :
     (pred == e1) || (write == e1)
   else ica es e1 e2.
 Proof.
-  rewrite /ica /fica frf_add_eventE fpred_add_eventE.
+  (* TODO: refactor rewriting of /ica, here and in similar contexts *)
+  rewrite /ica /= /dhrel_cnv /sfrel /fica /= frf_add_eventE fpred_add_eventE.
   by case: ifP=> ?; rewrite ?(andTb, andFb) ?orbF // ?inE eq_sym orbC eq_sym.
 Qed.
 
@@ -240,7 +241,8 @@ Proof.
   rewrite -cf_add_eventE //.
   apply/negP=> /eqP Ef.
   have /ica_fresh /eqP /(negP N) //: ica es fresh_id e1.
-  by rewrite /ica ?inE -Ef eq_refl.
+  (* TODO: refactor rewriting of /ica, here and in similar contexts *)
+  by rewrite /ica /= /dhrel_cnv /sfrel /fica /= ?inE -Ef eq_refl.
 Qed.
 
 Lemma consist_add_new_event: dom_consistency add_new_event.


### PR DESCRIPTION
This PR includes.

* An instance of relation-algebra's `monoid` structure for decidable relations of type `rel T` over `T : eqType`. 
Note that this monoid instance only provides: lattice operations (union, intersection, top, bottom, etc), identity relation `eq_op`, and converse `cnv`. Despite this limitation, still it allows us to use some notations ~~and lemmas~~ from relation-algebra. ~~Another drawback is that it requires us to use a custom fork of relation-algebra: https://github.com/eupp/relation-algebra/tree/monoid-decoupling.~~ I temporarily disabled all features that depend on the custom fork. It seems we currently don't need them. We'll see whether the custom fork will be accepted and merged into `relation-algebra`. 
  
* A refactoring of `sfrel`. In more detail, it reverses the direction of `sfrel` : `sfrel f == { <x , f x> }`. 
A theory of converse `cnv` from relation algebra is useful here when we apply `sfrel` to build causality relation because the latter is defined via _inverse_ covering function. 