### PR TITLE
Rewriting System

### DIFF
--- a/theories/common/rewriting_system.v
+++ b/theories/common/rewriting_system.v
@@ -268,14 +268,14 @@ Section SubRewriting.
 
 Local Open Scope ra_terms.
 
-Context {S L : Type} {p : rel.dset S}.
+Context {S L : Type} (p : rel.dset S).
 
 Definition sub (r : hrel S S) : hrel S S := r ⊓ (p × p).
 
-Lemma sub_p r x1 x2 : sub r x1 x2 -> p x2.
+Lemma sub_p {r x1 x2} : sub r x1 x2 -> p x2.
 Proof. by case=> ?/andP[]. Qed.
 
-Lemma sub_itr_p r x1 x2 : (sub r)^+ x1 x2 -> p x2.
+Lemma sub_itr_p {r x1 x2} : (sub r)^+ x1 x2 -> p x2.
 Proof. by rewrite itr_str_r=> [[??/sub_p]]. Qed.
 
 Context (r : L -> hrel S S) (e : hrel S S).

--- a/theories/common/rewriting_system.v
+++ b/theories/common/rewriting_system.v
@@ -333,17 +333,13 @@ End SubRewriting.
 
 Section SubTypeRewriting.
 
-Context {L : Type}.
+Context {L S T : Type}.
 
-Context {S : Type} (p : rel.dset S) (r1 : hrel S S) (e1 : hrel S S).
-
-Context {T : Type} (f : T -> S) (r2 : hrel T T) (e2 : hrel T T) .
+Context (p : rel.dset S) (r1 : hrel S S) (e1 : hrel S S) (f : T -> S).
 
 Definition relpreim r : hrel T T :=
   fun x y => r (f x) (f y).
 
-Hypothesis (morph_f_e1 : e2 ≡ relpreim e1).
-Hypothesis (morph_f_r1 : r2 ≡ relpreim (rst p r1)).
 Hypothesis (im : forall x, p x -> exists y, f y = x).
 
 Hypothesis (confl : eqv_confluent (rst p r1) e1).
@@ -365,9 +361,9 @@ Proof.
   by exists x=> //; rewrite /relpreim E.
 Qed.
 
-Lemma confl_sub : eqv_confluent r2 e2.
+Lemma confl_sub : eqv_confluent (relpreim (rst p r1)) (relpreim e1).
 Proof.
-  rewrite morph_f_e1 morph_f_r1 => ??? /=.
+  move=> ??? /=. 
   rewrite ?(relpreim_itr _ _) /relpreim=> /confl/[apply].
   case=> ? [?[/[dup]]] /(@rst_itr_p _ p)/im[s4<- ?].
   move/[dup]/(@rst_itr_p _ p)/im=>[s4'<- ?].
@@ -375,5 +371,3 @@ Proof.
 Qed.
 
 End SubTypeRewriting.
-
-


### PR DESCRIPTION
Here I add lemma `confl_sub`
If you take 
`S := exec_event_structure`
`p := dom_consistency`
`r1 := AddEvent.tr`
`e1 := eqv`
`T := cexec_event_structure`
`r2 :=  AddEvent.tr` contracted (how?) on `cexec_event_structure` (lets denote it as `CAddEvent.tr`)
`e2 := AddEvent.eqv` contracted (how?) on `cexec_event_structure` (lets denote it as `CAddEvent.eqv`)
`f := val`

Then `conflict_sub` says that 
```Coq
conflunent_eqv (AddEvent.tr ⊓  dom_consistency ×  dom_consistency) AddEvent.eqv
```
implies
```Coq
confluen_eqv CAddEvent.tr CAddEvent.eqv
```