### PR TITLE
Labelled posets and their homomorphisms

### DIFF
--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -149,13 +149,13 @@ Record class_of f := Class {
 }.
 Unset Primitive Projections.
 
-Structure type := Pack { homf ; _ : class_of homf }.
+Structure type := Pack { apply ; _ : class_of apply }.
 
-Local Coercion homf : type >-> Funclass.
+Local Coercion apply : type >-> Funclass.
 
 Variables (cT : type).
 
-Definition class := let: Pack _ c as cT' := cT return class_of (homf cT') in c.
+Definition class := let: Pack _ c as cT' := cT return class_of (apply cT') in c.
 Definition clone f c of phant_id class c := @Pack f c.
 
 (* Definition pack := *)
@@ -166,11 +166,11 @@ End Hom.
 
 Module Export Exports.
 Coercion mixin : class_of >-> mixin_of.
-Coercion homf : type >-> Funclass.
-Notation hom := type.
+Coercion apply : type >-> Funclass.
 End Exports.
 
 Module Export Syntax. 
+Notation hom := type.
 Notation "E1 ~> E2" := (hom E1 E2) (at level 50) : pomset_scope.
 End Syntax. 
 
@@ -178,13 +178,13 @@ Module Export Theory.
 Section Theory. 
 Context {L : Type} {E1 E2 : eventType L} (f : E1 ~> E2).
 
-Lemma lab_preserv e :
-  lab (f e) = lab e.
+Lemma lab_preserv :
+  { mono f : e / lab e }.
 Proof. by case: f => ? [[]]. Qed.
 
-Lemma monotone (e1 e2 : E1) :
-  e1 <= e2 -> f e1 <= f e2.
-Proof. by move: e1 e2; case: f => ? [[]]. Qed.
+Lemma monotone :
+  { homo f : e1 e2 / e1 <= e2 }.
+Proof. by case: f => ? [[]]. Qed.
 
 End Theory.
 End Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -15,9 +15,25 @@ From eventstruct Require Import utils.
 (*                               lposet structure itself (as opposed to       *)
 (*                               `eventType`) and for uniformity with the     *)
 (*                               theory of event structures.                  *)
-(*       LPoset.eventType L   == a type of events with labels of type L,      *)
+(*         LPoset.eventType L == a type of events with labels of type L,      *)
 (*                               i.e. a type equipped with canonical labelled *)
 (*                               poset structure instance.                    *)
+(*                        lab == labelling function                           *)
+(*                         ca == causality order                              *)
+(*                        sca == strict causality order                       *)
+(*                     x <= y == x preceds y in causality order. All          *)
+(*                               conventional order notations are as well.    *)
+(*                                                                            *)
+(*           LPoset.hom E1 E2 == a homomorphism between lposet types E1 and   *)
+(*                               E1 and E2, that is a label preserving        *) 
+(*                               monotone function.                           *)
+(*          LPoset.Hom.id     == identity homomorphism.                       *)
+(*          LPoset.Hom.tr f g == composition of homomorphisms (g \o f).       *)
+(*                                                                            *)
+(* Additionally, this file provides notations for homomorphisms which can     *)
+(* be used by importing corresponding module: `Import LPoset.Hom.Syntax`.     *)
+(*                   E1 ~> E2 == homomorphism                                 *)
+(*                                                                            *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -180,9 +196,9 @@ Proof. by exists id; do 2 constructor=> //. Defined.
 
 Definition tr {E1 E2 E3 : eventType L} : (E1 ~> E2) -> (E2 ~> E3) -> (E1 ~> E3).
 Proof. 
-  move=> f1 f2; exists (f2 \o f1); do 2 constructor=> /=.
+  move=> f g; exists (g \o f); do 2 constructor=> /=.
   - by move=> e; rewrite !lab_preserv.
-  by move=> e1 e2 /(monotone f1) /(monotone f2).
+  by move=> e1 e2 /(monotone f) /(monotone g).
 Defined.
 
 End Cat.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -18,11 +18,12 @@ From eventstruct Require Import utils.
 (*         LPoset.eventType L == a type of events with labels of type L,      *)
 (*                               i.e. a type equipped with canonical labelled *)
 (*                               poset structure instance.                    *)
-(*                        lab == labelling function                           *)
-(*                         ca == causality order                              *)
-(*                        sca == strict causality order                       *)
-(*                     x <= y == x preceds y in causality order. All          *)
-(*                               conventional order notations are as well.    *)
+(*                        lab == labelling function.                          *)
+(*                         ca == causality order.                             *)
+(*                        sca == strict causality order.                      *)
+(*                     x <= y == x preceds y in causality order.              *)
+(*                               All conventional order notations are         *)
+(*                               defined as well.                             *)
 (*                                                                            *)
 (*           LPoset.hom E1 E2 == a homomorphism between lposet types E1 and   *)
 (*                               E1 and E2, that is a label preserving        *) 
@@ -32,7 +33,7 @@ From eventstruct Require Import utils.
 (*                                                                            *)
 (* Additionally, this file provides notations for homomorphisms which can     *)
 (* be used by importing corresponding module: `Import LPoset.Hom.Syntax`.     *)
-(*                   E1 ~> E2 == homomorphism                                 *)
+(*                   E1 ~> E2 == homomorphism.                                *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -177,9 +178,9 @@ Module Export Theory.
 Section Theory. 
 Context {L : Type} {E1 E2 : eventType L} (f : E1 ~> E2).
 
-Lemma lab_preserv (e : E1) :
+Lemma lab_preserv e :
   lab (f e) = lab e.
-Proof. by move: e; case: f => ? [[]]. Qed.
+Proof. by case: f => ? [[]]. Qed.
 
 Lemma monotone (e1 e2 : E1) :
   e1 <= e2 -> f e1 <= f e2.
@@ -192,10 +193,10 @@ Section Cat.
 Context {L : Type}.
 
 Definition id {E : eventType L} : E ~> E.
-Proof. by exists id; do 2 constructor=> //. Defined.
+  by exists id; do 2 constructor=> //. 
+Defined.
 
 Definition tr {E1 E2 E3 : eventType L} : (E1 ~> E2) -> (E2 ~> E3) -> (E1 ~> E3).
-Proof. 
   move=> f g; exists (g \o f); do 2 constructor=> /=.
   - by move=> e; rewrite !lab_preserv.
   by move=> e1 e2 /(monotone f) /(monotone g).

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -112,6 +112,11 @@ Definition ca : rel E := le.
 (* strict causality alias *)
 Definition sca : rel E := lt.
 
+
+Definition ca_closed (X : pred E) : Prop :=
+  (* ca · [X] ≦ [X] · ca; *)
+  forall x y, x <= y -> X y -> X x.  
+
 End Def.
 End Def.
 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -5,26 +5,19 @@ From eventstruct Require Import utils.
 
 (******************************************************************************)
 (* This file provides a theory of pomsets.                                    *)
-(* Originally, the term pomset is an abbreviation for partially ordered       *)
-(* multiset. Since then the term has been widely used in the theory of        *)
-(* concurrency semantics. Here we use it following this tradition.            *)
-(* That is, our pomsets are not actually multisets, but rather usual sets.    *)
+(* The hierarchy of pomsets is based mathcomp's porderType.                   *)
 (*                                                                            *)
-(* We inheret most of the theory from mathcomp porderType.                    *)
-(* We add an axiom of finite cause, that is each event has only finite prefix *)
-(* of events on which it causally depends.                                    *)
-(*                                                                            *)
-(*       Pomset.eventStruct E == the type of pomset (event structures).       *)
-(*                               Pomset consists of partial causality order   *)
-(*                               (<=) which satisfies the axiom of finite     *)
-(*                               cause.                                       *)
+(*     LPoset.eventStruct E L == the type of partially ordered sets over      *) 
+(*                               elements of type E labeled by type L.        *)
+(*                               LPoset of partial causality order (<=) and   *) 
+(*                               labelling function lab.                      *)
 (*                               We use the name `eventStruct` to denote the  *)
-(*                               pomset structure itself (as opposed to       *)
+(*                               lposet structure itself (as opposed to       *)
 (*                               `eventType`) and for uniformity with the     *)
-(*                               theory of (prime and stable) event           *)
-(*                               structures.                                  *)
-(*       Pomset.eventType d   == a type of events, i.e. a type equipped with  *)
-(*                               pomset structure instance.                   *)
+(*                               theory of event structures.                  *)
+(*       LPoset.eventType L   == a type of events with labels of type L,      *)
+(*                               i.e. a type equipped with canonical labelled *)
+(*                               poset structure instance.                    *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -42,9 +35,9 @@ Delimit Scope pomset_scope with pomset.
 
 Local Open Scope pomset_scope.
 
-Module Pomset.
+Module LPoset.
 
-Module Export Pomset.
+Module Export LPoset.
 Section ClassDef. 
 
 Record mixin_of (E0 : Type) (eb : Order.POrder.class_of E0)
@@ -90,13 +83,13 @@ Coercion porderType : type >-> Order.POrder.type.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
-Notation PomsetType E L m := (@pack E L _ _ id m).
+Notation LPosetType E L m := (@pack E L _ _ id m).
 End Exports.
 
-End Pomset.
+End LPoset.
 
-Notation eventType := Pomset.type.
-Notation eventStruct := Pomset.class_of.
+Notation eventType := LPoset.type.
+Notation eventStruct := LPoset.class_of.
 
 Module Export Def.
 Section Def.
@@ -104,7 +97,7 @@ Section Def.
 Context {L : Type} {E : eventType L}.
 
 (* labeling function *)
-Definition lab : E -> L := Pomset.lab (Pomset.class E).
+Definition lab : E -> L := LPoset.lab (LPoset.class E).
 
 (* causality alias *)
 Definition ca : rel E := le.
@@ -191,8 +184,8 @@ End Cat.
 
 End Hom.
 
-End Pomset.
+End LPoset.
 
-Export Pomset.Pomset.Exports.
-Export Pomset.Def.
-Export Pomset.Hom.Exports.
+Export LPoset.LPoset.Exports.
+Export LPoset.Def.
+Export LPoset.Hom.Exports.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -105,7 +105,6 @@ Definition ca : rel E := le.
 (* strict causality alias *)
 Definition sca : rel E := lt.
 
-
 Definition ca_closed (X : pred E) : Prop :=
   (* ca · [X] ≦ [X] · ca; *)
   forall x y, x <= y -> X y -> X x.  
@@ -154,8 +153,13 @@ Coercion homf : type >-> Funclass.
 Notation hom := type.
 End Exports.
 
+Module Export Syntax. 
+Notation "E1 ~> E2" := (hom E1 E2) (at level 50) : pomset_scope.
+End Syntax. 
+
+Module Export Theory.
 Section Theory. 
-Context {L : Type} {E1 E2 : eventType L} (f : hom E1 E2).
+Context {L : Type} {E1 E2 : eventType L} (f : E1 ~> E2).
 
 Lemma lab_preserv (e : E1) :
   lab (f e) = lab e.
@@ -166,14 +170,15 @@ Lemma monotone (e1 e2 : E1) :
 Proof. by move: e1 e2; case: f => ? [[]]. Qed.
 
 End Theory.
+End Theory.
 
 Section Cat.
 Context {L : Type}.
 
-Definition id {E : eventType L} : hom E E.
+Definition id {E : eventType L} : E ~> E.
 Proof. by exists id; do 2 constructor=> //. Defined.
 
-Definition tr {E1 E2 E3 : eventType L} : hom E1 E2 -> hom E2 E3 -> hom E1 E3.
+Definition tr {E1 E2 E3 : eventType L} : (E1 ~> E2) -> (E2 ~> E3) -> (E1 ~> E3).
 Proof. 
   move=> f1 f2; exists (f2 \o f1); do 2 constructor=> /=.
   - by move=> e; rewrite !lab_preserv.
@@ -187,5 +192,7 @@ End Hom.
 End LPoset.
 
 Export LPoset.LPoset.Exports.
-Export LPoset.Def.
 Export LPoset.Hom.Exports.
+Export LPoset.Def.
+Export LPoset.Hom.Theory.
+

--- a/theories/concur/porf_eventstruct.v
+++ b/theories/concur/porf_eventstruct.v
@@ -949,11 +949,17 @@ Proof.
   move=> e'. rewrite mem_undup. done.
 Qed.
 
-Definition pomsetMixin :=
-  @Pomset.Pomset.Mixin E^c _ fin_cause_ca.
+Definition lposetMixin :=
+  @LPoset.LPoset.Mixin E^c (Order.POrder.class porderType) L lab.
 
-Canonical pomsetType := 
-  Eval hnf in PomsetType (dispC disp) E^c pomsetMixin.
+Canonical lposetType := 
+  @LPoset.LPoset.Pack L E^c (LPoset.LPoset.Class lposetMixin).
+
+Definition elem_porfMixin := 
+  @Elem.EventStruct.Mixin E^c L _ fin_cause_ca.
+
+Canonical elem_porfPrime := 
+  @Elem.EventStruct.Pack L E^c (Elem.EventStruct.Class elem_porfMixin).
 
 (* ************************************************************************* *)
 (*     Immediate Conflict                                                    *)
@@ -1135,14 +1141,15 @@ Variable (es : prime_porf_eventstruct).
 Notation "E ^c" := (causal E) (at level 2, format "E ^c").
 
 Lemma hered_porfes :
-  @hereditary (pomsetType es) <=%O (cf es).
+  @hereditary (lposetType es) <=%O (cf es).
 Proof. exact: cf_hereditaryR. Qed.
 
 Definition prime_porfMixin := 
-  @Prime.EventStruct.Mixin E^c _ (cf es) (cf_irrelf es (rf_ncf_dom_es es))
-    (cf_sym es) hered_porfes.
+  @Prime.EventStruct.Mixin E^c L _ 
+    (cf es) (cf_irrelf es (rf_ncf_dom_es es)) (cf_sym es) hered_porfes.
 
-Canonical prime_porfPrime := Prime.EventType (dispC disp) E^c prime_porfMixin.
+Canonical prime_porfPrime := 
+  @Prime.EventStruct.Pack L E^c (Prime.EventStruct.Class prime_porfMixin).
 
 End PrimePORFEventStruct.
 

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -65,19 +65,19 @@ Module Elem.
 Module Export EventStruct.
 Section ClassDef. 
 
-Record mixin_of (E0 : Type) (L : Type) (eb : Pomset.Pomset.class_of E0 L)
-                (E := Pomset.Pomset.Pack eb) := Mixin {
+Record mixin_of (E0 : Type) (L : Type) (eb : LPoset.LPoset.class_of E0 L)
+                (E := LPoset.LPoset.Pack eb) := Mixin {
   _ : fin_cause (ca : rel E)
 }.
 
 Set Primitive Projections.
 Record class_of (E : Type) (L : Type) := Class {
-  base  : Pomset.Pomset.class_of E L;
+  base  : LPoset.LPoset.class_of E L;
   mixin : mixin_of base;
 }.
 Unset Primitive Projections.
 
-Local Coercion base : class_of >-> Pomset.Pomset.class_of.
+Local Coercion base : class_of >-> LPoset.LPoset.class_of.
 
 Structure type (L : Type) := Pack { sort; _ : class_of sort L }.
 
@@ -90,27 +90,27 @@ Definition clone c of phant_id class c := @Pack E c.
 (* Definition clone_with disp' c of phant_id class c := @Pack disp' T c. *)
 
 Definition pack :=
-  fun bE b & phant_id (@Pomset.Pomset.class L bE) b =>
+  fun bE b & phant_id (@LPoset.LPoset.class L bE) b =>
   fun m => Pack (@Class E L b m).
 
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition pomsetType := @Pomset.Pomset.Pack L cT class.
+Definition lposetType := @LPoset.LPoset.Pack L cT class.
 End ClassDef.
 
 Module Export Exports.
-Coercion base : class_of >-> Pomset.Pomset.class_of.
+Coercion base : class_of >-> LPoset.LPoset.class_of.
 Coercion mixin : class_of >-> mixin_of.
 Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion pomsetType : type >-> Pomset.eventType.
+Coercion lposetType : type >-> LPoset.eventType.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
-Canonical pomsetType.
+Canonical lposetType.
 End Exports.
 
 End EventStruct.
@@ -181,7 +181,7 @@ Definition pack :=
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition pomsetType := @Pomset.Pomset.Pack L cT class.
+Definition lposetType := @LPoset.LPoset.Pack L cT class.
 Definition elemEventType := @Elem.EventStruct.Pack L cT class.
 End ClassDef.
 
@@ -192,12 +192,12 @@ Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion pomsetType : type >-> Pomset.eventType.
+Coercion lposetType : type >-> LPoset.eventType.
 Coercion elemEventType : type >-> Elem.eventType.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
-Canonical pomsetType.
+Canonical lposetType.
 Canonical elemEventType.
 End Exports.
 
@@ -282,7 +282,7 @@ Module EventStruct.
 Section ClassDef.
 
 Record mixin_of (E0 : Type) (L : Type) (b : Elem.EventStruct.class_of E0 L)
-                (E := Pomset.Pomset.Pack b) := Mixin {
+                (E := LPoset.LPoset.Pack b) := Mixin {
   gcf : pred {fset E};
 
   _ : forall (e : E), ~~ (gcf [fset e]);
@@ -316,7 +316,7 @@ Definition pack :=
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition pomsetType := @Pomset.Pomset.Pack L cT class.
+Definition lposetType := @LPoset.LPoset.Pack L cT class.
 Definition elemEventType := @Elem.EventStruct.Pack L cT class.
 End ClassDef.
 
@@ -327,12 +327,12 @@ Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion pomsetType : type >-> Pomset.eventType.
+Coercion lposetType : type >-> LPoset.eventType.
 Coercion elemEventType : type >-> Elem.eventType.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
-Canonical pomsetType.
+Canonical lposetType.
 Canonical elemEventType.
 End Exports.
 


### PR DESCRIPTION
This PR is a retake on `pomset.v`. 
It features several changes. 

1. In `pomset.v` the `Pomset` structure is renamed into `LPoset` (labeled partially ordered set) to avoid confusion. A labelling function is embedded into `LPoset` hierarchy. 

2. An axiom of finite cause is removed from `LPoset` (top of the hierarchy) and is moved to a new structure `Elem.eventStruct` that is an elementary event structure (which is a labelled poset + axiom if finite cause). Elementary event structures are then inherited by various subclasses of prime event structures, that is prime event structures with binary and general conflict. 

3. Definition of homomorphism between labelled posets is given, together with basic combinators (`id`, `tr`) and notations. 
