### PR TITLE
Pomset language definition and simple properties

### DIFF
--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -567,8 +567,81 @@ Notation iso := Iso.type.
 
 End LPoset.
 
-Export LPoset.LPoset.Exports.
-Export LPoset.Def.
+Export lPoset.lPoset.Exports.
+Export lPoset.Def.
 
-Export LPoset.Hom.Hom.Exports.
-Export LPoset.Hom.Theory.
+Export lPoset.Hom.Hom.Exports.
+Export lPoset.Bij.Bij.Exports.
+Export lPoset.Emb.Emb.Exports.
+Export lPoset.Iso.Iso.Exports.
+Export lPoset.Hom.Theory.
+Export lPoset.Bij.Theory.
+Export lPoset.Emb.Theory.
+
+Notation lposet := (lPoset.eventStruct).
+
+
+Module Pomset. 
+
+Implicit Types (L : Type).
+
+Import lPoset.Hom.Syntax.
+Import lPoset.Iso.Syntax.
+
+Record lang L := mk_lang { 
+  apply : lPoset.eventType L -> Prop;
+  _     : forall E1 E2 (f : E1 ~= E2), apply E1 -> apply E2;
+            
+}.
+
+Module Export Exports.
+Coercion apply : lang >-> Funclass.
+End Exports.
+
+Module Export Def.
+Section Def.
+
+Context {L : Type}.
+Implicit Types (P Q : lang L).
+
+Definition subsumes P Q : Prop := 
+  forall p, P p -> exists q, Q q /\ inhabited (q ~> p).
+
+End Def.
+End Def.
+
+Module Export Syntax.
+Notation "P ⊑ Q" := (subsumes P Q) (at level 69) : pomset_scope.
+End Syntax.
+
+Module Export Theory.
+Section Theory.
+
+Context {L : Type}.
+Implicit Types (P Q R : lang L).
+
+Lemma subsumes_refl P : 
+  P ⊑ P.
+Proof. 
+  move=> p HP; exists p; split=> //. 
+  constructor; exact/lPoset.Hom.id.
+Qed.
+
+Lemma subsumes_trans P Q R : 
+  P ⊑ Q -> Q ⊑ R -> P ⊑ R.
+Proof. 
+  move=> H1 H2 p HP. 
+  move: (H1 p HP)=> [q [HQ [f]]].
+  move: (H2 q HQ)=> [r [HR [g]]].
+  exists r; split=> //; constructor; exact/(lPoset.Hom.tr g f).
+Qed.
+
+End Theory.
+End Theory.
+
+End Pomset.
+
+Export Pomset.Exports.
+Export Pomset.Def.
+Export Pomset.Syntax.
+Export Pomset.Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -601,8 +601,8 @@ Module Export Exports.
 Coercion apply : lang >-> Funclass.
 End Exports.
 
-Module Export Def.
-Section Def.
+Module Lattice.
+Section Lattice.
 
 Context {L : Type}.
 Implicit Types (P Q : lang L).
@@ -646,6 +646,37 @@ Proof.
 Qed.  
 Canonical neg P := Lang (@negP P).
 
+End Lattice.
+
+Module Export Exports.
+
+Canonical Structure pomset_lang_lattice_ops L : lattice.ops := 
+  lattice.mk_ops (lang L) leq weq cup cap neg bot top.
+
+Global Instance pomset_lang_lattice_morph L : 
+  lattice.morphism BDL (@apply L).
+Proof. by constructor. Qed.
+
+Global Instance pomset_lang_lattice_laws L : 
+  lattice.laws (BDL+STR+CNV+DIV) (@pomset_lang_lattice_ops L).
+Proof.
+  have H: (lattice.laws BDL (@pomset_lang_lattice_ops L)). 
+  - by apply/(laws_of_injective_morphism (@apply L)).
+  by constructor; apply H. 
+Qed.
+
+End Exports.
+
+End Lattice.
+
+Export Lattice.Exports.
+
+Module Export Def.
+Section Def.
+
+Context {L : Type}.
+Implicit Types (P Q : lang L).
+
 Definition stronger P Q : Prop := 
   forall p, P p -> exists q, Q q /\ inhabited (q ~> p).
 
@@ -659,26 +690,6 @@ Module Export Syntax.
 Notation "P ⊑ Q" := (stronger P Q) (at level 69) : pomset_scope.
 Notation "P ↪ Q" := (supported P Q) (at level 69) : pomset_scope.
 End Syntax.
-
-Module Export Lattice.
-Section Lattice.
-
-Context {L : Type}.
-
-Canonical Structure ops : lattice.ops := 
-  lattice.mk_ops (lang L) leq weq cup cap neg bot top.
-
-Global Instance morph : lattice.morphism BDL (@apply L).
-Proof. by constructor. Qed.
-
-Global Instance laws : lattice.laws (BDL+STR+CNV+DIV) ops.
-Proof.
-  have H: (lattice.laws BDL ops); last by constructor; apply H. 
-  by apply/(laws_of_injective_morphism (@apply L)).
-Qed.
-
-End Lattice. 
-End Lattice.
 
 Module Export Theory.
 Section Theory.
@@ -741,7 +752,7 @@ End Theory.
 End Pomset.
 
 Export Pomset.Exports.
+Export Pomset.Lattice.Exports.
 Export Pomset.Def.
 Export Pomset.Syntax.
-Export Pomset.Lattice.
 Export Pomset.Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -7,15 +7,15 @@ From eventstruct Require Import utils.
 (* This file provides a theory of pomsets.                                    *)
 (* The hierarchy of pomsets is based mathcomp's porderType.                   *)
 (*                                                                            *)
-(*     LPoset.eventStruct E L == the type of partially ordered sets over      *) 
+(*     lPoset.eventStruct E L == the type of partially ordered sets over      *) 
 (*                               elements of type E labeled by type L.        *)
-(*                               LPoset of partial causality order (<=) and   *) 
+(*                               lPoset of partial causality order (<=) and   *) 
 (*                               labelling function lab.                      *)
 (*                               We use the name `eventStruct` to denote the  *)
 (*                               lposet structure itself (as opposed to       *)
 (*                               `eventType`) and for uniformity with the     *)
 (*                               theory of event structures.                  *)
-(*         LPoset.eventType L == a type of events with labels of type L,      *)
+(*         lPoset.eventType L == a type of events with labels of type L,      *)
 (*                               i.e. a type equipped with canonical labelled *)
 (*                               poset structure instance.                    *)
 (*                        lab == labelling function.                          *)
@@ -25,16 +25,16 @@ From eventstruct Require Import utils.
 (*                               All conventional order notations are         *)
 (*                               defined as well.                             *)
 (*                                                                            *)
-(*      LPoset.hom E1 E2 == homomorphism between lposets E1 and E2, that is   *)
+(*      lPoset.hom E1 E2 == homomorphism between lposets E1 and E2, that is   *)
 (*                          label preserving monotone function.               *)
-(*      LPoset.bij E1 E2 == bijective homomorphism between lposets E1 and E2. *)
-(*      LPoset.emb E1 E2 == embedding between lposets E1 and E2, that is      *)
+(*      lPoset.bij E1 E2 == bijective homomorphism between lposets E1 and E2. *)
+(*      lPoset.emb E1 E2 == embedding between lposets E1 and E2, that is      *)
 (*                          order-reflecting homomorphism.                    *)
-(*      LPoset.iso E1 E2 == isomorphism between lposets E1 and E2, that is    *)
+(*      lPoset.iso E1 E2 == isomorphism between lposets E1 and E2, that is    *)
 (*                          bijective order-reflecting homomorphism.          *)
 (*                                                                            *)
 (* Additionally, this file provides notations for homomorphisms which can     *)
-(* be used by importing corresponding module: Import LPoset.Mod.Syntax        *)
+(* be used by importing corresponding module: Import lPoset.Mod.Syntax        *)
 (* for Mod in {Hom, Bij, Emb, Iso}.                                           *)
 (*                   E1 ~> E2 == homomorphism.                                *)
 (*                   E1 ≃> E2 == bijective homomorphism.                      *)
@@ -43,9 +43,9 @@ From eventstruct Require Import utils.
 (*                                                                            *)
 (* Each module Mod in {Hom, Bij, Emb, Iso} also defines combinators which     *)
 (* can be used to build morphisms compositonally.                             *)
-(*          LPoset.Mod.id     == identity morphism.                           *)
-(*          LPoset.Mod.sy f   == inverse morphisms (for Iso only).            *)
-(*          LPoset.Mod.tr f g == composition of morphisms (g \o f).           *)
+(*          lPoset.Mod.id     == identity morphism.                           *)
+(*          lPoset.Mod.sy f   == inverse morphisms (for Iso only).            *)
+(*          lPoset.Mod.tr f g == composition of morphisms (g \o f).           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -64,9 +64,9 @@ Delimit Scope pomset_scope with pomset.
 
 Local Open Scope pomset_scope.
 
-Module LPoset.
+Module lPoset.
 
-Module Export LPoset.
+Module Export lPoset.
 Section ClassDef. 
 
 Record mixin_of (E0 : Type) (eb : Order.POrder.class_of E0)
@@ -112,13 +112,13 @@ Coercion porderType : type >-> Order.POrder.type.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
-Notation LPosetType E L m := (@pack E L _ _ id m).
+Notation lPosetType E L m := (@pack E L _ _ id m).
 End Exports.
 
-End LPoset.
+End lPoset.
 
-Notation eventType := LPoset.type.
-Notation eventStruct := LPoset.class_of.
+Notation eventType := lPoset.type.
+Notation eventStruct := lPoset.class_of.
 
 Module Export Def.
 Section Def.
@@ -126,7 +126,7 @@ Section Def.
 Context {L : Type} {E : eventType L}.
 
 (* labeling function *)
-Definition lab : E -> L := LPoset.lab (LPoset.class E).
+Definition lab : E -> L := lPoset.lab (lPoset.class E).
 
 (* causality alias *)
 Definition ca : rel E := le.
@@ -565,7 +565,7 @@ Notation bij := Bij.type.
 Notation emb := Emb.type.
 Notation iso := Iso.type.
 
-End LPoset.
+End lPoset.
 
 Export lPoset.lPoset.Exports.
 Export lPoset.Def.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -607,11 +607,15 @@ Implicit Types (P Q : lang L).
 Definition stronger P Q : Prop := 
   forall p, P p -> exists q, Q q /\ inhabited (q ~> p).
 
+Definition supported P Q : Prop := 
+  forall p, P p -> exists q, Q q /\ inhabited (p ~> q).
+
 End Def.
 End Def.
 
 Module Export Syntax.
 Notation "P ⊑ Q" := (stronger P Q) (at level 69) : pomset_scope.
+Notation "P ↪ Q" := (supported P Q) (at level 69) : pomset_scope.
 End Syntax.
 
 Module Export Theory.
@@ -634,6 +638,22 @@ Proof.
   move: (H1 p HP)=> [q [HQ [f]]].
   move: (H2 q HQ)=> [r [HR [g]]].
   exists r; split=> //; constructor; exact/(lPoset.Hom.tr g f).
+Qed.
+
+Lemma supported_refl P : 
+  P ↪ P. 
+Proof. 
+  move=> p HP; exists p; split=> //.
+  constructor; exact/lPoset.Hom.id.
+Qed.
+
+Lemma supported_trans P Q R : 
+  (P ↪ Q) -> (Q ↪ R) -> (P ↪ R). 
+Proof. 
+  move=> H1 H2 p HP. 
+  move: (H1 p HP)=> [q [HQ [f]]].
+  move: (H2 q HQ)=> [r [HR [g]]].
+  exists r; split=> //; constructor; exact/(lPoset.Hom.tr f g).
 Qed.
 
 End Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -624,6 +624,16 @@ Section Theory.
 Context {L : Type}.
 Implicit Types (P Q R : lang L).
 
+Lemma lang_iso_inv P : iso_inv P.
+Proof. by case: P. Qed.
+
+Lemma subsumes_subset P Q :
+  P ≦ Q -> P ⊑ Q. 
+Proof. 
+  move=> Hs p Hp; exists p; split; first exact /Hs. 
+  constructor; exact/lPoset.Hom.id. 
+Qed.
+  
 Lemma subsumes_refl P : 
   P ⊑ P.
 Proof. 
@@ -638,6 +648,13 @@ Proof.
   move: (H1 p HP)=> [q [HQ [f]]].
   move: (H2 q HQ)=> [r [HR [g]]].
   exists r; split=> //; constructor; exact/(lPoset.Hom.tr g f).
+Qed.
+
+Lemma supported_subset P Q :
+  P ≦ Q -> P ↪ Q. 
+Proof. 
+  move=> Hs p Hp; exists p; split; first exact /Hs. 
+  constructor; exact/lPoset.Bij.id. 
 Qed.
 
 Lemma supported_refl P : 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -604,14 +604,14 @@ Section Def.
 Context {L : Type}.
 Implicit Types (P Q : lang L).
 
-Definition subsumes P Q : Prop := 
+Definition stronger P Q : Prop := 
   forall p, P p -> exists q, Q q /\ inhabited (q ~> p).
 
 End Def.
 End Def.
 
 Module Export Syntax.
-Notation "P ⊑ Q" := (subsumes P Q) (at level 69) : pomset_scope.
+Notation "P ⊑ Q" := (stronger P Q) (at level 69) : pomset_scope.
 End Syntax.
 
 Module Export Theory.

--- a/theories/concur/porf_eventstruct.v
+++ b/theories/concur/porf_eventstruct.v
@@ -920,10 +920,10 @@ Proof.
 Qed.
 
 Definition lposetMixin :=
-  @LPoset.LPoset.Mixin E (Order.POrder.class porderType) L lab. 
+  @lPoset.lPoset.Mixin E (Order.POrder.class porderType) L lab. 
 
 Canonical lposetType := 
-  @LPoset.LPoset.Pack L E (LPoset.LPoset.Class lposetMixin).
+  @lPoset.lPoset.Pack L E (lPoset.lPoset.Class lposetMixin).
 
 Definition elem_porfMixin := 
   @Elem.EventStruct.Mixin E L _ fin_cause_ca.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -65,19 +65,19 @@ Module Elem.
 Module Export EventStruct.
 Section ClassDef. 
 
-Record mixin_of (E0 : Type) (L : Type) (eb : LPoset.LPoset.class_of E0 L)
-                (E := LPoset.LPoset.Pack eb) := Mixin {
+Record mixin_of (E0 : Type) (L : Type) (eb : lPoset.lPoset.class_of E0 L)
+                (E := lPoset.lPoset.Pack eb) := Mixin {
   _ : fin_cause (ca : rel E)
 }.
 
 Set Primitive Projections.
 Record class_of (E : Type) (L : Type) := Class {
-  base  : LPoset.LPoset.class_of E L;
+  base  : lPoset.lPoset.class_of E L;
   mixin : mixin_of base;
 }.
 Unset Primitive Projections.
 
-Local Coercion base : class_of >-> LPoset.LPoset.class_of.
+Local Coercion base : class_of >-> lPoset.lPoset.class_of.
 
 Structure type (L : Type) := Pack { sort; _ : class_of sort L }.
 
@@ -90,23 +90,23 @@ Definition clone c of phant_id class c := @Pack E c.
 (* Definition clone_with disp' c of phant_id class c := @Pack disp' T c. *)
 
 Definition pack :=
-  fun bE b & phant_id (@LPoset.LPoset.class L bE) b =>
+  fun bE b & phant_id (@lPoset.lPoset.class L bE) b =>
   fun m => Pack (@Class E L b m).
 
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition lposetType := @LPoset.LPoset.Pack L cT class.
+Definition lposetType := @lPoset.lPoset.Pack L cT class.
 End ClassDef.
 
 Module Export Exports.
-Coercion base : class_of >-> LPoset.LPoset.class_of.
+Coercion base : class_of >-> lPoset.lPoset.class_of.
 Coercion mixin : class_of >-> mixin_of.
 Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion lposetType : type >-> LPoset.eventType.
+Coercion lposetType : type >-> lPoset.eventType.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
@@ -181,7 +181,7 @@ Definition pack :=
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition lposetType := @LPoset.LPoset.Pack L cT class.
+Definition lposetType := @lPoset.lPoset.Pack L cT class.
 Definition elemEventType := @Elem.EventStruct.Pack L cT class.
 End ClassDef.
 
@@ -192,7 +192,7 @@ Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion lposetType : type >-> LPoset.eventType.
+Coercion lposetType : type >-> lPoset.eventType.
 Coercion elemEventType : type >-> Elem.eventType.
 Canonical eqType.
 Canonical choiceType.
@@ -282,7 +282,7 @@ Module EventStruct.
 Section ClassDef.
 
 Record mixin_of (E0 : Type) (L : Type) (b : Elem.EventStruct.class_of E0 L)
-                (E := LPoset.LPoset.Pack b) := Mixin {
+                (E := lPoset.lPoset.Pack b) := Mixin {
   gcf : pred {fset E};
 
   _ : forall (e : E), ~~ (gcf [fset e]);
@@ -316,7 +316,7 @@ Definition pack :=
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition lposetType := @LPoset.LPoset.Pack L cT class.
+Definition lposetType := @lPoset.lPoset.Pack L cT class.
 Definition elemEventType := @Elem.EventStruct.Pack L cT class.
 End ClassDef.
 
@@ -327,7 +327,7 @@ Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion lposetType : type >-> LPoset.eventType.
+Coercion lposetType : type >-> lPoset.eventType.
 Coercion elemEventType : type >-> Elem.eventType.
 Canonical eqType.
 Canonical choiceType.
@@ -488,7 +488,7 @@ Definition pack :=
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 Definition porderType := @Order.POrder.Pack tt cT class.
-Definition lposetType := @LPoset.LPoset.Pack L cT class.
+Definition lposetType := @lPoset.lPoset.Pack L cT class.
 Definition elemEventType := @Elem.EventStruct.Pack L cT class.
 End ClassDef.
 
@@ -499,7 +499,7 @@ Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
 Coercion porderType : type >-> Order.POrder.type.
-Coercion lposetType : type >-> LPoset.eventType.
+Coercion lposetType : type >-> lPoset.eventType.
 Coercion elemEventType : type >-> Elem.eventType.
 Canonical eqType.
 Canonical choiceType.


### PR DESCRIPTION
This PR features:

* definition of pomset language as a set of labelled posets `lPoset.eventType L -> Prop` invariant under labelled posets isomorphism;
* `lattice` instance for pomset languages (integration with `relation-algebra` package);
* definition of _stronger-than_ and _supported-by_ preorders over pomset languages.