### PR TITLE
Scheduling of a Pomset

### DIFF
--- a/theories/common/relalg.v
+++ b/theories/common/relalg.v
@@ -12,6 +12,20 @@ Unset Printing Implicit Defensive.
 Unset Strict Implicit.
 
 (* ************************************************************************** *)
+(*     Utilities                                                              *)
+(* ************************************************************************** *)
+
+Section PropUtils.
+Context {T : Type}.
+Implicit Types (P : T -> Prop).
+
+Lemma inh_nempty P : 
+  inhabited { x | P x } -> ~ (P ≦ bot).
+Proof. by move=> [] [] x Hx H; move: (H x Hx)=> //=. Qed.
+
+End PropUtils.
+
+(* ************************************************************************** *)
 (*     Cartesian product for lattice-valued functions                         *)
 (* ************************************************************************** *)
 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -758,15 +758,15 @@ Export Pomset.Syntax.
 Export Pomset.Theory.
 
 
-Module LLoset.
+Module lLoset.
 
-Module Export LLoset.
+Module Export lLoset.
 Section ClassDef. 
 
 Set Primitive Projections.
 Record class_of (E : Type) (L : Type) := Class { 
   base  : Order.Total.class_of E;
-  mixin : LPoset.LPoset.mixin_of L base;
+  mixin : lPoset.lPoset.mixin_of L base;
 }.
 Unset Primitive Projections.
 
@@ -782,7 +782,7 @@ Definition class := let: Pack _ c as cT' := cT return class_of (sort cT') L in c
 Definition clone c of phant_id class c := @Pack E c.
 
 Definition pack :=
-  fun bE b & phant_id (@LPoset.LPoset.class L bE) b =>
+  fun bE b & phant_id (@lPoset.lPoset.class L bE) b =>
   fun m => Pack (@Class E L b m).
 
 Definition eqType := @Equality.Pack cT class.
@@ -792,12 +792,12 @@ Definition latticeType := @Lattice.Pack tt cT class.
 Definition distrLatticeType := @DistrLattice.Pack tt cT class.
 Definition orderType := @Order.Total.Pack tt cT class.
 Definition lposetType := 
-  @LPoset.LPoset.Pack L cT (LPoset.LPoset.Class (mixin class)).
+  @lPoset.lPoset.Pack L cT (lPoset.lPoset.Class (mixin class)).
 End ClassDef.
 
 Module Export Exports.
 Coercion base : class_of >-> Order.Total.class_of.
-Coercion mixin : class_of >-> LPoset.LPoset.mixin_of.
+Coercion mixin : class_of >-> lPoset.lPoset.mixin_of.
 Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Coercion choiceType : type >-> Choice.type.
@@ -805,7 +805,7 @@ Coercion porderType : type >-> Order.POrder.type.
 Coercion latticeType : type >-> Lattice.type.
 Coercion distrLatticeType : type >-> DistrLattice.type.
 Coercion orderType : type >-> Order.Total.type.
-Coercion lposetType : type >-> LPoset.LPoset.type.
+Coercion lposetType : type >-> lPoset.lPoset.type.
 Canonical eqType.
 Canonical choiceType.
 Canonical porderType.
@@ -813,36 +813,36 @@ Canonical latticeType.
 Canonical distrLatticeType.
 Canonical orderType.
 Canonical lposetType.
-Notation LLosetType E L m := (@pack E L _ _ id m).
+Notation lLosetType E L m := (@pack E L _ _ id m).
 End Exports.
 
-End LLoset.
+End lLoset.
 
-Notation eventType := LLoset.type.
-Notation eventStruct := LLoset.class_of.
+Notation eventType := lLoset.type.
+Notation eventStruct := lLoset.class_of.
 
-End LLoset.
+End lLoset.
 
-Export LLoset.LLoset.Exports.
+Export lLoset.lLoset.Exports.
 
 
 Module Export Lin.
 
 Section Def. 
-Context {L : Type} (E : LPoset.eventType L).
+Context {L : Type} (E : lPoset.eventType L).
 
-Record lin (E' : LLoset.eventType L) : Prop := 
-  is_lin { _ : LPoset.hom E E' }.
+Record lin (E' : lLoset.eventType L) : Prop := 
+  is_lin { _ : lPoset.hom E E' }.
 
 End Def.
 
-Import LPoset.Hom.Syntax.
+Import lPoset.Hom.Syntax.
 
 Section Theory. 
-Context {L : Type} {E1 E2 : LPoset.eventType L}.
+Context {L : Type} {E1 E2 : lPoset.eventType L}.
 
 Lemma hom_lin : (E1 ~> E2) -> lin E2 ≦ lin E1.
-Proof. move=> f E2' [] g; constructor; exact /(LPoset.Hom.tr f g). Qed.
+Proof. move=> f E2' [] g; constructor; exact /(lPoset.Hom.tr f g). Qed.
 
 End Theory.  
 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -687,15 +687,13 @@ Section HomExt.
 Context {L : Type} {E1 E2 : lPoset.eventType L} (f : E1 ~> E2).
 
 Definition Ext : lPoset.eventType L.
-  exists E1; constructor. 
-  - exists (class E1). 
-    exists (HomExtOrder.le f) (HomExtOrder.lt f).
+  exists E1; unshelve (econstructor).
+  - exists (class E1), (HomExtOrder.le f) (HomExtOrder.lt f).
     + exact/HomExtOrder.lt_def.
     + exact/HomExtOrder.le_refl.
     + exact/HomExtOrder.le_antisym.
     + exact/HomExtOrder.le_trans. 
-  - constructor; exact/(@lab L E1). 
-  exact/(mixin_count (class E1)).
+  constructor; exact/(@lab L E1). 
 Defined.
 
 Definition ext_bij : E1 ≃> Ext.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -1127,6 +1127,14 @@ End Def.
 Section Theory. 
 Context {L : Type} {P : Pomset.lang L} {E1 E2 : lPoset.eventType L}.
 
+Lemma schedule_inh : 
+  schedulable P -> P E1 -> inhabited { E2 | schedule P E1 E2 }. 
+Proof. 
+  move=> Hd Hp; move: (Hd E1 Hp). 
+  move=> [] E2' [] [] Hp' Hl [] f. 
+  constructor; exists E2'=> //=. 
+Qed.  
+
 Lemma schedule_bij : (E1 ≈> E2) -> schedule P E2 ≦ schedule P E1.
 Proof. 
   move=> f E2' [] HP [] Hl [] g; repeat constructor=> //. 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -698,7 +698,7 @@ Definition Ext : lPoset.eventType L.
   exact/(mixin_count (class E1)).
 Defined.
 
-Definition ext_bij : E1 ≈> Ext.
+Definition ext_bij : E1 ≃> Ext.
   exists (id : E1 -> Ext).
   repeat constructor. 
   - exact/HomExtOrder.le_id_mono.
@@ -850,7 +850,7 @@ Definition stronger P Q : Prop :=
   forall p, P p -> exists q, Q q /\ inhabited (q ~> p).
 
 Definition supported P Q : Prop := 
-  forall p, P p -> exists q, Q q /\ inhabited (p ≈> q).
+  forall p, P p -> exists q, Q q /\ inhabited (p ≃> q).
 
 (* TODO: generalize stronger/supported to arbitary relation on posets 
  *   and introduce notation in the style of `homo` from `ssreflect`:
@@ -1019,7 +1019,7 @@ Proof.
 Qed.
 
 Definition lang : Pomset.lang L := 
-  Pomset.mk_lang iso_inv.
+  Pomset.Lang iso_inv.
 
 End Lang. 
 End Lang.
@@ -1044,18 +1044,6 @@ End lLoset.
 
 Export lLoset.lLoset.Exports.
 
-Module Export Schedule.
-Section Schedule.
-
-Context {L : Type}.
-Implicit Types (P : Pomset.lang L).
-
-Definition schedulable P : Prop := 
-  P ↪ P ⊓ @lLoset.lang L.
-
-End Schedule.
-End Schedule.
-
 
 Module Export Schedule.
 
@@ -1068,7 +1056,7 @@ Section Schedule.
 Context {L : Type} (P : Pomset.lang L) (E : lPoset.eventType L).
 
 Definition prop (E' : lPoset.eventType L) : Prop := 
-  P E' /\ lLoset.lang E' /\ inhabited (E ≈> E').
+  P E' /\ lLoset.lang E' /\ inhabited (E ≃> E').
 
 Lemma iso_inv : Pomset.iso_inv prop. 
 Proof. 
@@ -1079,7 +1067,7 @@ Proof.
 Qed.
 
 Definition lang : Pomset.lang L := 
-  Pomset.mk_lang iso_inv. 
+  Pomset.Lang iso_inv. 
 
 End Schedule. 
 End Schedule.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -893,6 +893,38 @@ Proof.
   exact /(lPoset.Bij.tr f g). 
 Qed.
 
+Lemma hom_lin : (E1 ~> E2) -> lin E2 ⊑ lin E1.
+Proof. 
+  (* For the proof of this lemma, we need to construct 
+   * a (decidable) linear extension of an arbitary partial order. 
+   * It is not possible to do this **constructively** in general. 
+   * It should be possible, however, under additional assumptions 
+   * on partial order. There are several directions we can take.
+   *
+   *  (1) Trivially, it is possible to construct linear extension 
+   *      for partial order over finite type.  
+   *
+   *  (2) It is possible for a finitely supported partial order over countable type.
+   *
+   *  (3) For a countable type if the partial order is embedded in
+   *      the total order induced by embedding into natural numbers.
+   *      That is `r x y -> x <=^n y`. 
+   *      Under this assumption there is a very simple way to extend 
+   *      the partial order to linear order: 
+   *      just link the elements unrelated by `r` according to their `<=^n` ordering. 
+   * 
+   *  (4) It can also be done for a partial order over countable type 
+   *      with finite width (width is the size of the largest antichain). 
+   *  
+   *  The (1) approach should work nicely for finite pomsets. 
+   *  For finitely supported pomsets we can actually combine (2) and (3). 
+   *  Since we are going to use finitly supported pomsets for operational semantics
+   *  we can enforce the axiom required by (3). 
+   *  As for (4) it is not obvious how it can be exploited in practice.
+   *)
+  admit. 
+Admitted.
+
 End Theory.  
 
 End Lin.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -728,29 +728,6 @@ Proof.
   by rewrite {2}/comparable=> -> ->.
 Qed.
 
-(* Lemma hom_incomp_linset (E1 E2 : lPoset.eventType L) (f : E1 ~> E2) e1 e2 : *)
-(*   lang E2 -> (e1 >< e2) -> f e1 = f e2. *)
-
-
-(* Lemma hack x y : (f x <= f y) -> (x <= y) || (x >< y). *)
-(* Proof.  *)
-(*   rewrite le_eqVlt=> /orP[]; last first. *)
-(*   - by move=> /ext_lt_rmono/ltW ->.  *)
-(*   move=> /eqP; case H: (x <= y)=> //=. *)
-(*   move=> ?; apply/negP=> /orP []. *)
-(*   - by rewrite H. *)
-
-(*   move=> /(monotone ext_hom)=> /=. *)
-
-(*   rewrite le_eqVlt=> /orP []. *)
-(*   - by move: H=> /[swap] /eqP ->; rewrite lexx. *)
-
-(*   - by move=> <-; rewrite lexx.  *)
-(*   move=> ??; apply/orP. *)
-(*   apply/negP=> /orP []. *)
-(*   apply/idP/idP; last first. *)
-(*   - move=> /orP. *)
-
 End HomExt.
 
 End lPoset.
@@ -784,7 +761,6 @@ Definition iso_inv {L} (P : lPoset.eventType L -> Prop) :=
 Record lang L := Lang { 
   apply : lPoset.eventType L -> Prop;
   _     : iso_inv apply;
-            
 }.
 
 Module Export Exports.
@@ -1055,16 +1031,6 @@ Context {L : Type}.
  *   i.e. make a conversion from `p : lPoset.eventType L` and 
  *   a proof of `lLoset.lang p` to `lLoset.eventType L` 
  *)
-(* Lemma hom_incomp_linset (E1 E2 : lPoset.eventType L) (f : E1 ~> E2) e1 e2 : *)
-(*   lang E2 -> (e1 >< e2) -> f e1 = f e2. *)
-(* Proof.  *)
-(*   move=> Ht /orP Hi. *)
-(*   move: (Ht (f e1) (f e2)); rewrite le_eqVlt. *)
-(*   move=> /orP[]; first move=> /orP[]. *)
-(*   - by move=> /eqP. *)
-(*   -  *)
-(*   case H: (e1 <= e2); move: H. *)
-  (* -  *)
 
 End Theory.
 End Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -69,16 +69,16 @@ Module lPoset.
 Module Export lPoset.
 Section ClassDef. 
 
-Record mixin_of (E0 : Type) (eb : Order.POrder.class_of E0)
-                (E := Order.POrder.Pack tt eb)
-                (L : Type) := Mixin {
+Record mixin_of (E0 : Type) (L : Type)
+                (eb : Order.POrder.class_of E0)
+                (E := Order.POrder.Pack tt eb) := Mixin {
   lab : E -> L
 }.
 
 Set Primitive Projections.
 Record class_of (E : Type) (L : Type) := Class {
   base  : Order.POrder.class_of E;
-  mixin : mixin_of base L;
+  mixin : mixin_of L base;
 }.
 Unset Primitive Projections.
 
@@ -756,3 +756,94 @@ Export Pomset.Lattice.Exports.
 Export Pomset.Def.
 Export Pomset.Syntax.
 Export Pomset.Theory.
+
+
+Module LLoset.
+
+Module Export LLoset.
+Section ClassDef. 
+
+Set Primitive Projections.
+Record class_of (E : Type) (L : Type) := Class { 
+  base  : Order.Total.class_of E;
+  mixin : LPoset.LPoset.mixin_of L base;
+}.
+Unset Primitive Projections.
+
+Local Coercion base : class_of >-> Order.Total.class_of.
+
+Structure type (L : Type) := Pack { sort; _ : class_of sort L }.
+
+Local Coercion sort : type >-> Sortclass.
+
+Variables (E : Type) (L : Type) (cT : type L).
+
+Definition class := let: Pack _ c as cT' := cT return class_of (sort cT') L in c.
+Definition clone c of phant_id class c := @Pack E c.
+
+Definition pack :=
+  fun bE b & phant_id (@LPoset.LPoset.class L bE) b =>
+  fun m => Pack (@Class E L b m).
+
+Definition eqType := @Equality.Pack cT class.
+Definition choiceType := @Choice.Pack cT class.
+Definition porderType := @Order.POrder.Pack tt cT class.
+Definition latticeType := @Lattice.Pack tt cT class.
+Definition distrLatticeType := @DistrLattice.Pack tt cT class.
+Definition orderType := @Order.Total.Pack tt cT class.
+Definition lposetType := 
+  @LPoset.LPoset.Pack L cT (LPoset.LPoset.Class (mixin class)).
+End ClassDef.
+
+Module Export Exports.
+Coercion base : class_of >-> Order.Total.class_of.
+Coercion mixin : class_of >-> LPoset.LPoset.mixin_of.
+Coercion sort : type >-> Sortclass.
+Coercion eqType : type >-> Equality.type.
+Coercion choiceType : type >-> Choice.type.
+Coercion porderType : type >-> Order.POrder.type.
+Coercion latticeType : type >-> Lattice.type.
+Coercion distrLatticeType : type >-> DistrLattice.type.
+Coercion orderType : type >-> Order.Total.type.
+Coercion lposetType : type >-> LPoset.LPoset.type.
+Canonical eqType.
+Canonical choiceType.
+Canonical porderType.
+Canonical latticeType.
+Canonical distrLatticeType.
+Canonical orderType.
+Canonical lposetType.
+Notation LLosetType E L m := (@pack E L _ _ id m).
+End Exports.
+
+End LLoset.
+
+Notation eventType := LLoset.type.
+Notation eventStruct := LLoset.class_of.
+
+End LLoset.
+
+Export LLoset.LLoset.Exports.
+
+
+Module Export Lin.
+
+Section Def. 
+Context {L : Type} (E : LPoset.eventType L).
+
+Record lin (E' : LLoset.eventType L) : Prop := 
+  is_lin { _ : LPoset.hom E E' }.
+
+End Def.
+
+Import LPoset.Hom.Syntax.
+
+Section Theory. 
+Context {L : Type} {E1 E2 : LPoset.eventType L}.
+
+Lemma hom_lin : (E1 ~> E2) -> lin E2 ≦ lin E1.
+Proof. move=> f E2' [] g; constructor; exact /(LPoset.Hom.tr f g). Qed.
+
+End Theory.  
+
+End Lin.

--- a/theories/concur/porf_eventstruct.v
+++ b/theories/concur/porf_eventstruct.v
@@ -920,7 +920,7 @@ Proof.
 Qed.
 
 Definition lposetMixin :=
-  @lPoset.lPoset.Mixin E (Order.POrder.class porderType) L lab. 
+  @lPoset.lPoset.Mixin E L (Order.POrder.class porderType) lab.
 
 Canonical lposetType := 
   @lPoset.lPoset.Pack L E (lPoset.lPoset.Class lposetMixin).


### PR DESCRIPTION
The main contribution of this PR is the notion of the scheduling of `lposet` and `pomset`. 
A schedule of labelled poset is a set of its totally ordered extensions. Scheduling of a pomset is a union of these extensions for each of the posets belonging to the pomset. Scheduling will be used later to connect pomset semantics with trace semantics. 

The main proven lemmas are `schedule_hom`, `scheduling_unistronger` and `scheduling_stronger` which describe how schedulings of `lposets` and `pomsets` behave with respect to homomorphisms. 

An auxiliary very helpful notion developed in this PR is `Ext` --- an extension of `lposet` `p` by another `lposet` `q` under the assumption that there exists a homomorphism from `p` to `q` (or in other words, the order in `q` should not contradict the order in `p`).