### PR TITLE
Adjoin operation on traces 

### DIFF
--- a/theories/concur/lts.v
+++ b/theories/concur/lts.v
@@ -206,36 +206,36 @@ End Step.
 
 Module Export Trace. 
 
-Notation trace_seq S := (seq (step S)).
+Notation traceSeq S := (seq (step S)).
 
 Section Def. 
 Context {L : Type} (S : ltsType L).
 
-Definition is_trace : pred (trace_seq S) := 
+Definition is_trace : pred (traceSeq S) := 
   fun ts => sorted adj ts.
 
 Structure trace : Type := Trace { 
-  trace_val :> trace_seq S; 
+  trace_val :> traceSeq S; 
   _         :  is_trace trace_val;
 }.
 
 Canonical trace_subType := Eval hnf in [subType for trace_val].
 
-Implicit Types (ts : trace_seq S) (tr : trace).
+Implicit Types (ts : traceSeq S) (tr : trace).
 
-Definition labels : trace_seq S -> seq L := map (lbl : step S -> L). 
+Definition labels : traceSeq S -> seq L := map (lbl : step S -> L). 
 
-Definition states : S -> trace_seq S -> seq S := 
+Definition states : S -> traceSeq S -> seq S := 
   fun s ts => 
     match ts with 
     | [::]    => [:: s] 
     | st :: _ => src st :: map (dst : step S -> S) ts
     end. 
 
-Definition fst_state : S -> trace_seq S -> S := 
+Definition fst_state : S -> traceSeq S -> S := 
   fun s ts => if ts is st :: ts then src st else s.
 
-Definition lst_state : S -> trace_seq S -> S := 
+Definition lst_state : S -> traceSeq S -> S := 
   fun s ts => if ts is st :: ts then dst (last st ts) else s. 
 
 Definition trace_lang : S -> pred trace := 
@@ -245,7 +245,7 @@ Definition trace_lang : S -> pred trace :=
 Definition lts_lang : S -> lang L := 
   fun s w => exists2 tr, trace_lang s tr & w = labels tr.
 
-Definition adjoint : rel (trace_seq S) := 
+Definition adjoint : rel (traceSeq S) := 
   fun ts1 ts2 => 
     match ts2 with 
     | [::]    => true
@@ -261,7 +261,7 @@ Arguments adjoint : simpl never.
 
 Section Seq.
 Context {L : Type} (S : ltsType L).
-Implicit Types (st : step S) (s : trace_seq S) (tr : trace S).
+Implicit Types (st : step S) (s : traceSeq S) (tr : trace S).
 
 Lemma nil_traceP : is_trace ([::] : seq (step S)).
 Proof. done. Qed.
@@ -285,7 +285,7 @@ End EQ.
 
 Section Theory. 
 Context {L : Type} (S : ltsType L).
-Implicit Types (st : step S) (ts : trace_seq S) (tr : trace S).
+Implicit Types (st : step S) (ts : traceSeq S) (tr : trace S).
 
 Lemma trace_adj tr : sorted adj tr.
 Proof. by case: tr. Qed.

--- a/theories/concur/lts.v
+++ b/theories/concur/lts.v
@@ -252,8 +252,8 @@ Definition adjoint : rel (traceSeq S) :=
     | st :: _ => lst_state (src st) ts1 == src st
     end.
 
-Definition adjoin : traceSeq S -> traceSeq S -> traceSeq S := 
-  fun ts1 ts2 => if adjoint ts1 ts2 then ts1 ++ ts2 else ts1. 
+Definition adjoin : traceSeq S -> traceSeq S -> traceSeq S :=
+  fun ts1 ts2 => if adjoint ts1 ts2 then ts1 ++ ts2 else [::].
 
 Definition mk_trace tr mkTr : trace :=
   mkTr (let: Trace _ trP := tr return is_trace tr in trP).
@@ -276,6 +276,10 @@ Notation "st '<+' tr" := [trace of adjoin [:: st] tr]
 
 Notation "tr '+>' st" := [trace of adjoin tr [:: st]]
   (at level 48, left associativity) : lts_scope.
+
+(* TODO: make traces an intance of partial monoid, 
+ *   reuse general monoid notations.
+ *)
 
 Section Build.
 Context {L : Type} (S : ltsType L).
@@ -416,7 +420,8 @@ Lemma labels_cat ts1 ts2 :
   labels (ts1 ++ ts2) = labels ts1 ++ labels ts2.
 Proof. by rewrite /labels map_cat. Qed.
 
-Lemma size_states s ts : size (states s ts) == (size ts).+1.
+Lemma size_states s ts : 
+  size (states s ts) == (size ts).+1.
 Proof. by rewrite /states; case: ts=> [|??] //=; rewrite size_map. Qed.
                          
 Lemma states_rcons s ts st : s = fst_state (src st) ts -> 
@@ -426,6 +431,14 @@ Proof. by case: ts=> [->|??] //=; rewrite map_rcons. Qed.
 Lemma states_cat s ts1 ts2 : s = fst_state s ts2 -> 
   states s (ts1 ++ ts2) = states s ts1 ++ behead (states s ts2).
 Proof. by rewrite /states map_cat; case: ts1; case: ts2=> //= ?? ->. Qed.
+
+Lemma adjoin0s tr : 
+  [trace] <+> tr = tr.
+Proof. by apply/val_inj=> /=; rewrite adjoin_val ?adjoint0s //=. Qed.  
+
+Lemma adjoins0 tr : 
+  tr <+> [trace] = tr.
+Proof. by apply/val_inj=> /=; rewrite adjoin_val ?adjoints0 ?cats0 //=. Qed.
 
 End Theory.
 

--- a/theories/concur/lts.v
+++ b/theories/concur/lts.v
@@ -21,6 +21,8 @@ From eventstruct Require Import utils relalg.
 (*                      from s1 to s2.                                        *)
 (*            step S == a type of steps of the LTS.                           *)
 (*                   := { (lbl, src, dst) | src --[lbl]--> dst }.             *)
+(*         step_of H == given a proof of step property H : s --[l]--> s'      *)
+(*                      constructs a step { (l, s, s') | s --[l]--> s' }.     *)
 (*           trace S == a type of traces of the LTS, that is finite sequences *)
 (*                      of steps performed by the transition system.          *)
 (*                   := { tr : seq (step S) | dst tr[i] == src tr[i+1] }.     *)
@@ -28,10 +30,16 @@ From eventstruct Require Import utils relalg.
 (*                      Coq must be able to infer a proof that ts satisfies   *)
 (*                      trace property (i.e the ends of steps should match).  *)
 (*           [trace] == empty trace.                                          *)
-(*         labels tr == a sequence of labels of tr.                           *)
-(*       states s tr == a sequence of states of tr or [:: s] is tr is empty.  *)
-(*    fst_state s tr == the first state of of tr or s is tr is empty.         *)
-(*    lst_state s tr == the last state of of tr or s is tr is empty.          *)
+(*       tr1 <+> tr2 == concatenation of traces tr1 ++ tr2 if tr1 and tr2     *)
+(*                      are adjoint, empty trace otherwise.                   *)
+(*          st <+ tr == cons of step st and trace tr if they are are adjoint, *)
+(*                      empty trace otherwise.                                *)
+(*          tr +> st == rcons of step st and trace tr if they are are adjoint,*)
+(*                      empty trace otherwise.                                *)
+(*         labels tr == a sequence of labels of a trace.                      *)
+(*       states s tr == a sequence of states of tr or [:: s] if tr is empty.  *)
+(*    fst_state s tr == the first state of tr or s is tr is empty.            *)
+(*    lst_state s tr == the last state of tr or s is tr is empty.             *)
 (*   adjoint tr1 tr2 == a relation asserting that two traces are adjoint,     *)
 (*                      meaning that the last state of tr1 is equal to        *)
 (*                      the first state of tr2.                               *)
@@ -247,6 +255,7 @@ Definition states : S -> traceSeq S -> seq S :=
     | st :: _ => src st :: map (dst : step S -> S) ts
     end. 
 
+(* TODO: try `starts_with` and `ends_with` predicates instead? *)
 Definition fst_state : S -> traceSeq S -> S := 
   fun s ts => if ts is st :: ts then src st else s.
 

--- a/theories/concur/lts.v
+++ b/theories/concur/lts.v
@@ -277,9 +277,6 @@ Notation "st '<+' tr" := [trace of adjoin [:: st] tr]
 Notation "tr '+>' st" := [trace of adjoin tr [:: st]]
   (at level 48, left associativity) : lts_scope.
 
-(* TODO: make traces an intance of partial monoid, 
- *   reuse general monoid notations.
- *)
 
 Section Build.
 Context {L : Type} (S : ltsType L).


### PR DESCRIPTION
Introduce `adjoin` operation to concatenate traces (returns empty trace if concatenated traces are not adjoint).
Use new combinators on traces to simplify `sim_lang` lemma proof. 