### PR TITLE
Minor changes in `relalg.v `

### DIFF
--- a/theories/common/rel.v
+++ b/theories/common/rel.v
@@ -109,7 +109,7 @@ Definition rt_closure : {dhrel T & T} :=
 (* ************************************************************************** *)
 
 Lemma t_closure_1nP x y : 
-  reflect (clos_trans_1n T (sfrel f) x y) (t_closure x y).
+  reflect (clos_trans_1n (sfrel f) x y) (t_closure x y).
 Proof.
   rewrite /t_closure; funelim (suffix x)=> /=. 
   apply /(iffP idP); rewrite mem_cat /sfrel /=.
@@ -123,14 +123,14 @@ Proof.
 Qed.
 
 Lemma t_closureP x y :
-  reflect (clos_trans T (sfrel f) x y) (t_closure x y).
+  reflect (clos_trans (sfrel f) x y) (t_closure x y).
 Proof.
   apply /(equivP (t_closure_1nP x y)).
   symmetry; exact: clos_trans_t1n_iff.
 Qed.
 
 Lemma clos_trans_gt : 
-  clos_trans T (sfrel f) ≦ (>%O : rel T).
+  clos_trans (sfrel f) ≦ (>%O : rel T).
 Proof. 
   move=> ??; rewrite/sfrel /=.
   elim=> [y z /descend | x y z _ ] //=.
@@ -153,7 +153,7 @@ Proof.
 Qed.
 
 Lemma rt_closureP x y :
-  reflect (clos_refl_trans T (sfrel f) x y) (rt_closure x y).
+  reflect (clos_refl_trans (sfrel f) x y) (rt_closure x y).
 Proof.
   apply /equivP; last first.
   { rewrite clos_refl_transE clos_refl_hrel_qmk. 
@@ -346,7 +346,7 @@ Arguments clos_t1n_trans {_ _ _ _}.
 Arguments t1n_trans _ {_ _ _ _}.
 
 Lemma t_closure_n1P x y: 
-  reflect (clos_trans_1n T (sfrel f) x y) (t_closure x y).
+  reflect (clos_trans_1n (sfrel f) x y) (t_closure x y).
 Proof.
   apply: (iffP flatten_mapP)=> [[z]|]. 
   - move=> /rt_closure_1nP H ?. apply/clos_trans_t1n/clos_rt_t.

--- a/theories/common/rel.v
+++ b/theories/common/rel.v
@@ -156,7 +156,7 @@ Lemma rt_closureP x y :
   reflect (clos_refl_trans (sfrel f) x y) (rt_closure x y).
 Proof.
   apply /equivP; last first.
-  { rewrite clos_refl_transE clos_refl_hrel_qmk. 
+  { rewrite clos_rt_crE clos_r_qmk. 
     apply or_iff_compat_l; symmetry.
     apply rwP; exact: t_closureP. }
   rewrite /t_closure /rt_closure /wsuffix in_cons eq_sym /=.
@@ -359,7 +359,7 @@ Proof.
     by apply/rt_closure_1nP/clos_rt1n_step.
   move=> {}y {}z' ??. exists y=> //.
   apply/rt_closure_1nP/rt1n_trans; first exact: H. 
-  by apply/clos_rt_rt1n/clos_t_clos_rt/clos_tn1_trans.
+  by apply/clos_rt_rt1n/clos_t_rt/clos_tn1_trans.
 Qed.
 
 End FinRTClosure.

--- a/theories/common/relalg.v
+++ b/theories/common/relalg.v
@@ -403,14 +403,14 @@ Implicit Types (R : hrel T T) (r : rel T).
 (* TODO: consider to reformulate it in terms of relation-algebra 
  * (or try to just use kat tactics inplace) 
  *)
-Lemma clos_t_clos_rt R x y :
+Lemma clos_t_rt R x y :
   clos_trans R x y -> clos_refl_trans R x y.
 Proof.
   elim=> [|???? H ??]; first by constructor.
   by apply: rt_trans H _.
 Qed.
 
-Lemma clos_refl_transE R :
+Lemma clos_rt_crE R :
   clos_refl_trans R ≡ clos_refl (clos_trans R).
 Proof.
   move=> x y; split.
@@ -422,14 +422,14 @@ Proof.
   by apply: rt_trans H _.
 Qed.
 
-Lemma clos_refl_hrel_qmk R :
+Lemma clos_r_qmk R :
   clos_refl R ≡ R^?.
 Proof.
   split; first by case; [right | left].
   case=> [->|]; first exact: r_refl; exact: r_step.
 Qed.
 
-Lemma clos_trans_1n_hrel_itr R :
+Lemma clos_t1n_itr R :
   clos_trans_1n R ≡ R^+.
 Proof.
   move=> x y; split.
@@ -441,18 +441,18 @@ Proof.
   by apply: Relation_Operators.t1n_trans xz ct_zy.
 Qed.
 
-Lemma clos_trans_hrel_itr R :
+Lemma clos_t_itr R :
   clos_trans R ≡ R^+.
 Proof.
   move=> x y; rewrite clos_trans_t1n_iff.
-  by apply: clos_trans_1n_hrel_itr.
+  by apply: clos_t1n_itr.
 Qed.
 
-Lemma clos_refl_trans_hrel_str R : 
+Lemma clos_rt_str R : 
   clos_refl_trans R ≡ R^*. 
 Proof. 
-  rewrite str_itr clos_refl_transE clos_refl_hrel_qmk.
-  by rewrite /qmk clos_trans_hrel_itr. 
+  rewrite str_itr clos_rt_crE clos_r_qmk.
+  by rewrite /qmk clos_t_itr. 
 Qed.
 
 End RelClos.

--- a/theories/common/relalg.v
+++ b/theories/common/relalg.v
@@ -44,22 +44,22 @@ Notation "p × q" := (cart_prod p q) (at level 60, no associativity) : ra_terms.
 (*     Reflexive closure                                                      *)
 (* ************************************************************************** *)
 
-Definition qmk {X : ops} n (x : X n n) := (1 ⊔ x).
+(* Definition qmk {X : ops} n (x : X n n) := (1 ⊔ x). *)
 
-Notation "r ^?" := (qmk r) (left associativity, at level 5, format "r ^?"): ra_terms.
+Notation "r ^?" := (1 ⊔ r) (left associativity, at level 5, format "r ^?"): ra_terms.
 
-Lemma qmkE `{laws} n (x : X n n) :
-  x^? ≡ 1 ⊔ x.
-Proof. by rewrite /qmk; apply: weq_Reflexive. Qed.
+(* Lemma qmkE `{laws} n (x : X n n) : *)
+(*   x^? ≡ 1 ⊔ x. *)
+(* Proof. by rewrite /qmk; apply: weq_Reflexive. Qed. *)
 
 Lemma itr_qmk `{laws} `{BKA ≪ l} n (x : X n n) :
   x^+^? ≡ x^?^+.
-Proof. rewrite /qmk; ka. Qed.
+Proof. by ka. Qed.
 
 (* TODO: make lemma instance of Proper for rewriting? *)
 Lemma qmk_weq `{laws} `{BKA ≪ l} n (x y : X n n): 
   x ≡ y -> x^? ≡ y^?.
-Proof. by rewrite /qmk=> ->. Qed.
+Proof. by move => ->. Qed.
 
 
 (* ************************************************************************** *)
@@ -80,7 +80,7 @@ Lemma qmk_sub_one `{CUP+CAP+TOP ≪ l} x :
   (x \ 1)^? ≡ x^?.
 Proof. 
   apply/weq_spec; split; first by lattice.
-  by rewrite /qmk -[x in _ + x]capxt -eq_dec capcup; lattice.
+  by rewrite -[x in _ + x]capxt -eq_dec capcup; lattice.
 Qed.
 
 End SubtractionTheory. 
@@ -452,7 +452,7 @@ Lemma clos_rt_str R :
   clos_refl_trans R ≡ R^*. 
 Proof. 
   rewrite str_itr clos_rt_crE clos_r_qmk.
-  by rewrite /qmk clos_t_itr. 
+  by rewrite clos_t_itr. 
 Qed.
 
 End RelClos.

--- a/theories/common/relalg.v
+++ b/theories/common/relalg.v
@@ -44,13 +44,7 @@ Notation "p × q" := (cart_prod p q) (at level 60, no associativity) : ra_terms.
 (*     Reflexive closure                                                      *)
 (* ************************************************************************** *)
 
-(* Definition qmk {X : ops} n (x : X n n) := (1 ⊔ x). *)
-
 Notation "r ^?" := (1 ⊔ r) (left associativity, at level 5, format "r ^?"): ra_terms.
-
-(* Lemma qmkE `{laws} n (x : X n n) : *)
-(*   x^? ≡ 1 ⊔ x. *)
-(* Proof. by rewrite /qmk; apply: weq_Reflexive. Qed. *)
 
 Lemma itr_qmk `{laws} `{BKA ≪ l} n (x : X n n) :
   x^+^? ≡ x^?^+.

--- a/theories/common/rewriting_system.v
+++ b/theories/common/rewriting_system.v
@@ -230,9 +230,9 @@ Hypothesis edcomm : diamond_commute e r.
 Theorem rconfl_eqv : eqv_rconfluent.
 Proof.
   suff: eqv_confluent (r^?) e.
-  - move=> C ???; rewrite !(str_itr r _ _) -qmkE !(itr_qmk r _ _).
+  - move=> C ???; rewrite !(str_itr r _ _) !(itr_qmk r _ _).
     move=>/C/[apply][[s4 [s4' [*]]]]; exists s4, s4'.
-    by split=> //; rewrite !(str_itr r _ _) -qmkE !(itr_qmk r _ _).
+    by split=> //; rewrite !(str_itr r _ _) !(itr_qmk r _ _).
   apply/confl_eqv=> //.
   - move=> s1 s2 s3 [-> [->| ?]|R [<-|/(edconfl _ _ _ R)]] //.
     - exists s3, s3; split; by [left|left|apply/eqv_refl].

--- a/theories/common/rewriting_system.v
+++ b/theories/common/rewriting_system.v
@@ -230,9 +230,9 @@ Hypothesis edcomm : diamond_commute e r.
 Theorem rconfl_eqv : eqv_rconfluent.
 Proof.
   suff: eqv_confluent (r^?) e.
-  - move=> C ???; rewrite ?(str_itr r _ _) ?(itr_qmk r _ _).
+  - move=> C ???; rewrite !(str_itr r _ _) -qmkE !(itr_qmk r _ _).
     move=>/C/[apply][[s4 [s4' [*]]]]; exists s4, s4'.
-    by split=> //; rewrite ?(str_itr r _ _) ?(itr_qmk r _ _).
+    by split=> //; rewrite !(str_itr r _ _) -qmkE !(itr_qmk r _ _).
   apply/confl_eqv=> //.
   - move=> s1 s2 s3 [-> [->| ?]|R [<-|/(edconfl _ _ _ R)]] //.
     - exists s3, s3; split; by [left|left|apply/eqv_refl].

--- a/theories/concur/porf_eventstruct.v
+++ b/theories/concur/porf_eventstruct.v
@@ -784,10 +784,10 @@ Qed.
 Definition ca : rel E := (rt_closure fca_gt)°.
 
 Lemma closureP e1 e2 :
-  reflect (clos_refl_trans _ ica e1 e2) (ca e1 e2).
+  reflect (clos_refl_trans ica e1 e2) (ca e1 e2).
 Proof. 
   rewrite /ca /ica. apply weq_reflect.
-  rewrite !clos_refl_trans_hrel_str.
+  rewrite !clos_rt_str.
   rewrite rel_cnv_m -kleene.cnvstr.
   apply cnv_weq_iff.
   rewrite cnv_invol str_itr itr_qmk.
@@ -800,7 +800,7 @@ Proof.
     by apply /rel_weq_m; rewrite -strictify_weq.
   rewrite rel_qmk_m.
   rewrite -itr_qmk -str_itr.
-  rewrite -clos_refl_trans_hrel_str.
+  rewrite -clos_rt_str.
   apply /reflect_weq/rt_closureP.
 Qed.
 


### PR DESCRIPTION
* set implicit arguments for `clos_trans` and related definitions from vanilla Coq library.
* shorter names for lemmas relating closure operation definitions from vanilla coq and relation-algebra package
* prove `connect_strP` lemma for reflexive-transitive closure of finite relations