### PR TITLE
Simplify Hierarchy of Event Structures

### DIFF
--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -323,9 +323,31 @@ Qed.
 End FoldUtils. 
 
 Section FSetUtils.
-
-Context {T : choiceType}.
+Context {T U : choiceType}.
 Implicit Types (s : {fset T}) (p : pred T) (r : rel T).
+Implicit Types (f : T -> U).
+
+Local Open Scope fset_scope.
+
+Lemma imfset1 f x : 
+  f @` ([fset x]) = [fset (f x)].
+Proof. 
+  apply/fsetP=> y /=; rewrite !inE. 
+  apply/idP/idP=> [/imfsetP|].
+  - by move=> [] z /=; rewrite inE=> /eqP-> ->.
+  move=> /eqP->; apply/imfsetP; exists x=> //=; exact/fset11.
+Qed.
+
+Lemma imfsetU f s1 s2 : 
+  f @` (s1 `|` s2) = (f @` s1) `|` (f @` s2).
+Proof. 
+  apply/fsetP=> x /=; rewrite !inE. 
+  apply/idP/idP=> [/imfsetP|].
+  - move=> [] y /=; rewrite !inE=> + ->.
+    by move=> /orP[?|?]; apply/orP; [left|right]; apply/imfsetP; exists y.
+  by move=> /orP[|] /imfsetP[] /= y ? ->; apply/imfsetP; exists y=> //; 
+    rewrite inE; apply/orP; [left|right].
+Qed.
 
 Lemma fset_existsP s p :
   reflect (exists x, x \in s /\ p x) [exists x : s, p (val x)].

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -347,6 +347,26 @@ Proof.
   by apply /fset_existsP; exists y.
 Qed.  
 
+Lemma fset_forallP s p :
+  reflect (forall x, x \in s -> p x) [forall x : s, p (val x)].
+Proof.
+  apply /equivP; first (by apply /forallP); split.
+  - by move=> H x inX; move: (H (Sub x inX)).  
+  move=> H x; exact/H/(valP x).
+Qed.  
+
+(* TODO: use `rst s r` (restriction of relation) ? *)
+Lemma fset_forall2P s r :
+  reflect (forall x y, x \in s -> y \in s -> r x y) 
+          [forall x : s, forall y : s, r (val x) (val y)].
+Proof.
+  apply /equivP; last split. 
+  - by apply/(@fset_forallP _ (fun x => [forall y, r x (val y)])).
+  - move=> H x y inX inY; move: (H x inX). 
+    by move=> /forallP=> Hy; move: (Hy (Sub y inY)).
+  move=> H x Hx /=; apply/forallP=> y; exact/H.
+Qed.    
+
 End FSetUtils.
 
 

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -370,7 +370,7 @@ Proof.
 Qed.  
 
 Lemma fset_forallP s p :
-  reflect (forall x, x \in s -> p x) [forall x : s, p (val x)].
+  reflect {in s, forall x, p x} [forall x : s, p (val x)].
 Proof.
   apply /equivP; first (by apply /forallP); split.
   - by move=> H x inX; move: (H (Sub x inX)).  
@@ -379,7 +379,7 @@ Qed.
 
 (* TODO: use `rst s r` (restriction of relation) ? *)
 Lemma fset_forall2P s r :
-  reflect (forall x y, x \in s -> y \in s -> r x y) 
+  reflect {in s & s, forall x y, r x y}
           [forall x : s, forall y : s, r (val x) (val y)].
 Proof.
   apply /equivP; last split. 

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -541,7 +541,7 @@ Lemma comp_class {E1 E2 E3} (f : {emb  E2 -> E3}) (g : {emb E1 -> E2}) :
 Proof. 
   split=> //; first exact/Hom.Build.comp_class; split.
   - by case: (lPoset.Emb.Build.comp_mixin [emb of g]%pomset [emb of f]%pomset).
-  by move=> ?; rewrite imfset_comp=> /cons_antimon/cons_antimon.
+  by move=> ?; rewrite imfset_comp !cons_emb. 
 Qed.
 
 Lemma of_eqfun_class {E1 E2} (f : {emb  E1 -> E2}) g :
@@ -549,7 +549,7 @@ Lemma of_eqfun_class {E1 E2} (f : {emb  E1 -> E2}) g :
 Proof.
   move=> E; split=> //; first exact/Hom.Build.of_eqfun_class; split.
   - by case: (lPoset.Emb.Build.of_eqfun_class E)=> ? [].
-  by move=> X; rewrite (eq_imfset _ E (fun=> erefl))=> /cons_antimon.
+  by move=> X; rewrite (eq_imfset _ E (fun=> erefl)) cons_emb.
 Qed.
 
 Definition of_eqfun {E1 E2} (f : {emb  E1 -> E2}) g : g =1 f -> {emb  E1 -> E2} := 
@@ -945,7 +945,7 @@ Lemma inv_class {E1 E2} (f : {iso E1 -> E2}) :
 Proof.
   case: (lPoset.Iso.Build.inv_class [iso of f]%pomset)=> [[[[??[g ??[?]]]]]].
   do ? split=> //; [|by exists g|].
-  - move=> ??; apply/(@cons_antimon _ _ _ f); rewrite -imfset_comp.
+  - move=> ??; rewrite -(cons_emb f) -imfset_comp.
     under eq_imfset do [rewrite /= can_inv|by []]; by rewrite /= imfset_id.
   move=> ? /(@cons_mon _ _ _ f); rewrite -imfset_comp.
   under eq_imfset do [rewrite /= can_inv|by []]; by rewrite /= imfset_id.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -144,7 +144,7 @@ Definition gcf : pred {fset E} :=
   fun C => ~~ cons C.
 
 Definition cf : rel E := 
-  fun e1 e2 => gcf ([fset e1; e2]).
+  fun e1 e2 => gcf [fset e1; e2].
 
 Definition cf_free (p : pred E) := 
   forall (s : {fset E}), {subset s <= p} -> cons s.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -218,7 +218,7 @@ Definition gcf : pred {fset E} :=
   fun C => ~~ cons C.
 
 Definition cf : rel E := 
-  fun e1 e2 => gcf ([fset e1] `|` [fset e2]).
+  fun e1 e2 => gcf ([fset e1; e2]).
 
 Definition cf_free (p : pred E) := 
   forall (s : {fset E}), {subset s <= p} -> cons s.
@@ -230,9 +230,9 @@ End Def.
 
 Prenex Implicits cons gcf cf.
 
-(* Module Export Syntax. *)
-(* Notation cons := cons (only parsing). *)
-(* End Syntax. *)
+Module Export Syntax.
+Notation "x \# y" := (cf x y) : prime_eventstruct_scope.
+End Syntax.
 
 Module Export Theory.
 Section Theory.
@@ -259,6 +259,31 @@ Proof. by rewrite /gcf=> /cons_contr /contra. Qed.
 Lemma gcf_hered X e1 e2 : 
   e1 <= e2 -> gcf (e1 |` X) -> gcf (e2 |` X).
 Proof. by rewrite /gcf=> /cons_prop /contra /[apply]. Qed.
+
+Lemma cf_irrefl : irreflexive (cf : rel E).
+Proof. 
+  move=> e; rewrite /cf fsetUid; apply/eqP.
+  rewrite eqbF_neg; exact/gcf_self.
+Qed.
+
+Lemma cf_sym : symmetric (cf : rel E).
+Proof. by move=> e1 e2; rewrite /cf fsetUC. Qed.
+
+Lemma cf_hered : hereditary (<=%O) (cf : rel E).
+Proof. 
+  move=> e1 e2 e3 /[swap]; rewrite /cf. 
+  rewrite [in [fset e1; e2]]fsetUC [in [fset e1; e3]]fsetUC.
+  exact/gcf_hered.
+Qed.
+
+(* TODO: better name? *)
+Lemma cf_hered2 e1 e1' e2 e2' : 
+  e1 \# e2 -> e1 <= e1' -> e2 <= e2' -> e1' \# e2'.
+Proof. 
+  move=> cf12 ca1 ca2; apply/(cf_hered _ ca2).
+  rewrite cf_sym; apply/(cf_hered _ ca1).
+  by rewrite cf_sym.
+Qed.
 
 Lemma cons_ca_contr (X Y : {fset E}) :
   {subsumes X <= Y : x y / x <= y} -> cons Y -> cons X.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -324,6 +324,17 @@ Proof.
   by case: f => ? [[[??[]]]]; apply.
 Qed.
 
+Lemma gcf_mon (X : {fset E1}) : 
+  gcf (f @` X) -> gcf X.
+Proof. exact/contra/cons_mon. Qed.
+
+Lemma cf_mon e1 e2 :
+  cf (f e1) (f e2) -> cf e1 e2.
+Proof. 
+  rewrite /cf=> ?; apply/gcf_mon.
+  by rewrite imfsetU !imfset1=> /=.
+Qed.
+
 Lemma hom_cf_free (C1 : pred E1) (C2 : pred E2) : 
   (forall x, C2 x <-> exists2 y, C1 y & x = f y) ->
   cf_free C1 -> cf_free C2.
@@ -480,6 +491,7 @@ Module Export Theory.
 Section Theory. 
 Context {L : Type} {E1 E2 : eventType L} (f : {emb E1 -> E2}).
 
+(* TODO: cons (f @` X) = cons X. *)
 Lemma cons_antimon (X : {fset E1}) : 
   cons (f @` X) -> cons X.
 Proof. case: f => ? [? [? []]]; exact. Qed.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -491,17 +491,34 @@ Module Export Theory.
 Section Theory. 
 Context {L : Type} {E1 E2 : eventType L} (f : {emb E1 -> E2}).
 
-(* TODO: cons (f @` X) = cons X. *)
-Lemma cons_antimon (X : {fset E1}) : 
-  cons (f @` X) -> cons X.
-Proof. case: f => ? [? [? []]]; exact. Qed.
+(* TODO: rename? *)
+Lemma cons_emb (X : {fset E1}) : 
+  cons (f @` X) = cons X.
+Proof. 
+  apply/idP/idP; last first.
+  - exact/cons_mon.
+  case: f => ? [? [? []]]; exact. 
+Qed.
+
+Lemma gcf_emb (X : {fset E1}) : 
+  gcf (f @` X) = gcf X.
+Proof. by rewrite /gcf cons_emb. Qed.
+
+Lemma cf_emb : 
+  {mono f : e1 e2 / cf e1 e2}.
+Proof. 
+  rewrite /cf=> e1 e2 /=.
+  rewrite -imfset1 -imfset1 -imfsetU.
+  exact/gcf_emb.
+Qed.
 
 Lemma emb_cf_free (C1 : pred E1) (C2 : pred E2) : 
   (forall x, C2 x <-> exists2 y, C1 y & x = f y) ->
   cf_free C1 <-> cf_free C2.
 Proof.
   move=> CE; split=> [/(hom_cf_free CE) //| cf s S].
-  apply/cons_antimon/cf=> ? /imfsetP[y /S ? ->].
+  rewrite -cons_emb; apply/cf=> ?.
+  move=> /imfsetP[y /S ? ->].
   by apply/CE; exists y.
 Qed.
 

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -170,7 +170,7 @@ Lemma cons_self e : cons [fset e].
 Proof. by move: e; case: E => ? [? []] ?? []. Qed.
 
 (* TODO: rename `cons_contra`? *)
-Lemma cons_contr X Y : X `<=` Y -> cons Y -> cons X.
+Lemma cons_contra X Y : X `<=` Y -> cons Y -> cons X.
 Proof. by move: X Y; case: E => ? [? []] ?? []. Qed.
 
 Lemma cons_prop X e1 e2 : 
@@ -181,7 +181,7 @@ Lemma gcf_self e : ~~ (gcf [fset e]).
 Proof. rewrite /gcf negbK; exact/cons_self. Qed.
 
 Lemma gcf_ext X Y : X `<=` Y -> gcf X -> gcf Y.
-Proof. by rewrite /gcf=> /cons_contr /contra. Qed.
+Proof. by rewrite /gcf=> /cons_contra /contra. Qed.
 
 Lemma gcf_hered X e1 e2 : 
   e1 <= e2 -> gcf (e1 |` X) -> gcf (e2 |` X).
@@ -220,11 +220,11 @@ Proof.
   rewrite fsubUset !fsub1set; exact/andP.
 Qed.
 
-Lemma cons_ca_contr (X Y : {fset E}) :
+Lemma cons_ca_contra (X Y : {fset E}) :
   {subsumes X <= Y : x y / x <= y} -> cons Y -> cons X.
 Proof.
   move: X {2}(X `\` Y) (erefl (X `\` Y))=> /[swap].
-  elim/fset_ind=> [?/eqP/[! fsetD_eq0]/cons_contr//|].
+  elim/fset_ind=> [?/eqP/[! fsetD_eq0]/cons_contra//|].
   move=> x ?? IHxy X XYE /[dup] S + cY; rewrite -(@fsetD1K _ x X); last first.
   - move/fsetP/(_ x): XYE; rewrite ?inE eqxx andbC /=; by case: (x \in X).
   case/(_ x)=> [/[! (inE, eqxx)]//|y ? /cons_prop]; apply.
@@ -240,7 +240,7 @@ Proof. move=> e1 e2 /=; exact: le_trans. Qed.
 
 Lemma prefix_cf_free e : cf_free (<= e).
 Proof. 
-  move=> X S; apply/(@cons_ca_contr _ [fset e])/cons_self.
+  move=> X S; apply/(@cons_ca_contra _ [fset e])/cons_self.
   move=> x i; exists e; rewrite ?inE //; exact/S.
 Qed.
 
@@ -1119,7 +1119,7 @@ Proof.
 Qed.  
 
 (* TODO: rename cons_of_contra? *)
-Lemma cons_contr (X Y : {fset E}) : X `<=` Y -> cons Y -> cons X.
+Lemma cons_contra (X Y : {fset E}) : X `<=` Y -> cons Y -> cons X.
 Proof.
   move=> sub /= /fset_exists2P nCF. 
   apply/fset_exists2P=> [[]] x [] y [].
@@ -1150,7 +1150,7 @@ Proof.
 Qed.
 
 Definition primeCMixin := 
-  PrimeC.EventStruct.Mixin cons_self cons_contr cons_prop.
+  PrimeC.EventStruct.Mixin cons_self cons_contra cons_prop.
 
 Definition primeCeventType := 
   PrimeC.EventStruct.Pack (PrimeC.EventStruct.Class (class E) primeCMixin).


### PR DESCRIPTION
* Remove elementary event structures `Elem.EventStruct`, instead inherit `PrimeC` from `DwFinPOrder`
* Remove `PrimeG` event structures, define `gcf` and `cf` on `PrimeC` event structures.
* Add `gcf` and `cf` morhpism lemmas. 
* Inherit `Prime` from `PrimeC`, prove `bgcfP` and `bgcfE` lemmas to express general conflict through binary conflict.