### PR TITLE
Pomset utils

### DIFF
--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -21,7 +21,7 @@ depends: [
   "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.14.0~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1") | (= "dev")}
-  "coq-mathcomp-tarjan" {(>= "1.0.0") | (= "dev")}
+  "coq-mathcomp-tarjan" {(>= "1.0.0")}
   "coq-mathcomp-zify" {(>= "1.0.0") | (= "dev")}
   "coq-relation-algebra" {(>= "1.7.4") | (= "dev")}
   "coq-equations" {(>= "1.2") | (= "dev")}

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -21,7 +21,7 @@ depends: [
   "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.14.0~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1") | (= "dev")}
-  "coq-mathcomp-tarjan" {(>= "1.0.0")}
+  "coq-mathcomp-tarjan" {(= "dev")}
   "coq-mathcomp-zify" {(>= "1.0.0") | (= "dev")}
   "coq-relation-algebra" {(>= "1.7.4") | (= "dev")}
   "coq-equations" {(>= "1.2") | (= "dev")}

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -29,7 +29,7 @@ depends: [
   "coq-equations" {(>= "1.2") | (= "dev")}
 ]
 pin-depends: [
-  [ "coq-relation-algebra.dev" "git+https://github.com/math-comp/tarjan/"]
+  [ "coq-mathcomp-tarjan.dev" "git+https://github.com/math-comp/tarjan/"]
 ]
 conflicts: [
   "coq-equations" {(= "dev+HoTT")}

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -29,7 +29,7 @@ depends: [
   "coq-equations" {(>= "1.2") | (= "dev")}
 ]
 pin-depends: [
-  [ "coq-mathcomp-tarjan.dev" "--dev-repo"]
+  [ "coq-relation-algebra.dev" "git+https://github.com/math-comp/tarjan/"]
 ]
 conflicts: [
   "coq-equations" {(= "dev+HoTT")}

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -21,6 +21,8 @@ depends: [
   "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.14.0~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1") | (= "dev")}
+  # we fix dev version, because 1.0 and dev 
+  # use different module names (Kosaraju.v vs kosaraju.v)
   "coq-mathcomp-tarjan" {(= "dev")}
   "coq-mathcomp-zify" {(>= "1.0.0") | (= "dev")}
   "coq-relation-algebra" {(>= "1.7.4") | (= "dev")}

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -30,6 +30,7 @@ depends: [
 ]
 pin-depends: [
   [ "coq-mathcomp-tarjan.dev" "--dev-repo"]
+]
 conflicts: [
   "coq-equations" {(= "dev+HoTT")}
 ]

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -21,13 +21,13 @@ depends: [
   "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.14.0~") | (= "dev")}
   "coq-mathcomp-finmap" {(>= "1.5.1") | (= "dev")}
-  # we fix dev version, because 1.0 and dev 
-  # use different module names (Kosaraju.v vs kosaraju.v)
   "coq-mathcomp-tarjan" {(= "dev")}
   "coq-mathcomp-zify" {(>= "1.0.0") | (= "dev")}
   "coq-relation-algebra" {(>= "1.7.4") | (= "dev")}
   "coq-equations" {(>= "1.2") | (= "dev")}
 ]
+# we pin dev version, because 1.0.0 and dev 
+# use different module names (Kosaraju.v vs kosaraju.v)
 pin-depends: [
   [ "coq-mathcomp-tarjan.dev" "git+https://github.com/math-comp/tarjan/"]
 ]

--- a/coq-eventstruct.opam
+++ b/coq-eventstruct.opam
@@ -28,6 +28,8 @@ depends: [
   "coq-relation-algebra" {(>= "1.7.4") | (= "dev")}
   "coq-equations" {(>= "1.2") | (= "dev")}
 ]
+pin-depends: [
+  [ "coq-mathcomp-tarjan.dev" "--dev-repo"]
 conflicts: [
   "coq-equations" {(= "dev+HoTT")}
 ]

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -2,7 +2,7 @@ From Coq Require Import Relations.
 From mathcomp Require Import ssreflect ssrbool ssrnat ssrfun.
 From mathcomp Require Import eqtype choice order seq tuple path zify.
 From mathcomp Require Import fintype finfun fingraph finmap.
-From mathcomp.tarjan Require Import extra acyclic Kosaraju acyclic_tsorted. 
+From mathcomp.tarjan Require Import extra acyclic kosaraju acyclic_tsorted. 
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -1294,3 +1294,15 @@ Proof.
 Qed.
 
 End Imfset.
+
+Section FinMapCount.
+Variable (K : countType) (V : countType).
+
+Definition finMap_countMixin := CanCountMixin (@finMap_codeK K V).
+Canonical finMap_countType := CountType {fmap K -> V} finMap_countMixin.
+
+Definition fsfun_countMixin d := [countMixin of fsfun d by <:].
+Canonical fsfun_countType d := CountType (fsfun d) (fsfun_countMixin d).
+
+End FinMapCount.
+

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -2,7 +2,7 @@ From Coq Require Import Relations.
 From mathcomp Require Import ssreflect ssrbool ssrnat ssrfun.
 From mathcomp Require Import eqtype choice order seq tuple path zify.
 From mathcomp Require Import fintype finfun fingraph finmap.
-From mathcomp.tarjan Require Import extra acyclic. 
+From mathcomp.tarjan Require Import extra acyclic Kosaraju acyclic_tsorted. 
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -1138,7 +1138,8 @@ Definition SubFinfunOf f P : P f -> sub_finfun_of (Phant (aT -> rT)) P :=
 
 End Def.
 
-Notation "{ 'ffun' fT '|' P }" := (sub_finfun_of (Phant fT) P).
+Notation "{ 'ffun' fT '|' P }" := (sub_finfun_of (Phant fT) P)
+  (at level 0, format "{ 'ffun'  fT '|' P }") : type_scope.
 
 Section Instances.
 Context {aT : finType}.

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -476,6 +476,13 @@ Proof.
   rewrite !sub_liftF //; exact/Hg.
 Qed.
 
+Lemma sub_rel_lift_val r (x y : S) : 
+  sub_rel_lift r (val x) (val y) = r x y.
+Proof. 
+  rewrite /sub_rel_lift /= !insubT; try exact/valP.
+  by move=> ??; rewrite !sub_val.
+Qed.
+
 Lemma sub_rel_lift_fld r : 
   subrel (sub_rel_lift r) [rel x y | P x && P y].
 Proof. 

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -1326,3 +1326,44 @@ Canonical fsfun_countType d := CountType (fsfun d) (fsfun_countMixin d).
 
 End FinMapCount.
 
+
+Section FinMapUtils.
+Context {K : choiceType} {V : eqType}.
+Implicit Types (A : {fset K}).
+
+Lemma finsupp_fset (A : {fset K}) (f : K -> V) dflt : 
+  finsupp [fsfun k in A => f k | dflt] = [fset k in A | f k != dflt]%fset. 
+Proof. 
+  apply/fsetP=> x. 
+  rewrite mem_finsupp fsfunE in_fset !inE /=. 
+  by case: (x \in A)=> //; rewrite eq_refl.
+Qed.
+
+Context {P : pred K} {fK : subFinType P}.
+
+Lemma in_fsetval k :
+  (k \in [fsetval k' in fK])%fset = (insub k : option fK).
+Proof. 
+  case: insubP=> /=. 
+  - move=> k' ? <-; apply/idP/idP=> //.
+    by apply/imfsetP; exists k'. 
+  move=> /negP nPe. 
+  apply/idP/idP=> //; apply/negP. 
+  move=> /imfsetP[k''] /= ? H; apply/nPe.
+  by move: (valP k''); rewrite H.
+Qed.
+
+Lemma in_fsetval_seq k (s : seq fK) :
+  (k \in [fsetval k' in s])%fset = 
+    if insub k is Some k' then k' \in s else false.
+Proof. 
+  case: insubP=> /=. 
+  - move=> k' ? <-; apply/idP/idP=> //.
+    + by move=> /imfsetP[k''] /= + /val_inj ->. 
+    by move=> ?; apply/imfsetP; exists k'.
+  move=> /negP nPk; apply/idP/idP=> //.
+  apply/negP=> /imfsetP[k''] /= ? H.
+  by move: (valP k''); rewrite -H.
+Qed.  
+
+End FinMapUtils.

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -1220,6 +1220,7 @@ End Subsumes.
 Section FinGraph. 
 Context {T : finType}.
 Implicit Types (g : rel T). 
+Implicit Types (gf : T -> seq T). 
 
 Lemma connect_refl g : 
   reflexive (connect g).
@@ -1231,6 +1232,25 @@ Proof.
   move=> /acyclic_symconnect_eq symconE x y.
   move: (symconE x y); rewrite /symconnect.
   by move=> -> /eqP.
+Qed.
+
+Lemma mem_tseq gf : 
+  tseq gf =i enum T.
+Proof. 
+  move: (tseq_correct gf)=> [_ in_tseq]. 
+  apply/subset_eqP/andP; split; apply/subsetP; last first.
+  - move=> x ?; exact/in_tseq. 
+  by move=> ?; rewrite mem_enum.
+Qed.
+
+Lemma size_tseq gf : 
+  size (tseq gf) = #|T|.
+Proof. 
+  rewrite cardT; apply/eqP. 
+  rewrite -uniq_size_uniq.
+  - exact/tseq_uniq.
+  - exact/enum_uniq.
+  move=> ?; exact/esym/mem_tseq.
 Qed.
 
 End FinGraph. 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -465,19 +465,19 @@ Proof.
   by rewrite mem_tseq fintype.mem_enum. 
 Qed.
 
-Lemma fs_idx_lt p e :
-  e \in finsupp p -> fs_idx p e < #|`finsupp p|.
+Lemma lfsp_idx_lt p e :
+  e \in finsupp p -> lfsp_idx p e < #|`finsupp p|.
 Proof. 
   rewrite /fs_idx=> in_supp.
   rewrite -lfsp_tseq_size ltEnat /=. 
   by rewrite index_mem mem_lfsp_tseq.
 Qed.  
 
-Lemma fs_idx_le p e :
-  fs_idx p e <= #|`finsupp p|.
+Lemma lfsp_idx_le p e :
+  lfsp_idx p e <= #|`finsupp p|.
 Proof. 
   case: (e \in finsupp p)/idP.
-  - by move=> /fs_idx_lt /ltW.
+  - by move=> /lfsp_idx_lt /ltW.
   move=> /negP Nin_supp.
   rewrite /fs_idx memNindex ?lfsp_tseq_size //.
   by rewrite mem_lfsp_tseq. 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -333,7 +333,7 @@ Module Export Theory.
 Section Theory.
 Context {E : identType} {L : eqType}.
 Variable (bot : L).
-Implicit Types (p : @lfsposet E L bot).
+Implicit Types (p q : @lfsposet E L bot).
 
 Lemma fs_labE p (e : [Event of p]) : 
   lab e = fs_lab p e.  
@@ -346,6 +346,28 @@ Proof. done. Qed.
 Lemma fs_scaE p (e1 e2 : [Event of p]) : 
   sca e1 e2 = fs_sca p e1 e2.  
 Proof. done. Qed.
+
+Lemma fs_rcov_fsupp p e :
+  fs_rcov p e `<=` finsupp p.
+Proof.
+  apply/fsubsetPn=> [[e']] /=.
+  move: (lfsposet_supp p)=> /supp_closedP. 
+  by move=> /[apply] /andP[??] /negP.
+Qed.
+
+Lemma lfsposet_eqP p q : 
+  reflect (fs_lab p =1 fs_lab q /\ fs_ica p =2 fs_ica q) (p == q).
+Proof. 
+  apply/(equivP idP); split=> [/eqP->|[]] //.
+  rewrite /fs_lab /fs_ica=> eq_lab eq_ica.
+  apply/eqP/val_inj=> /=.
+  apply/fsfunP=> e /=; apply/eqP.
+  rewrite /eq_op=> /=; apply/andP; split.
+  - by rewrite (eq_lab e).
+  apply/fset_eqP=> e'.
+  move: (eq_ica e' e)=> /=.
+  by rewrite /fs_rcov.
+Qed.
 
 End Theory.
 End Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -3,7 +3,7 @@ From RelationAlgebra Require Import lattice monoid rel boolean.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq tuple.
 From mathcomp Require Import eqtype choice order generic_quotient.
 From mathcomp Require Import fintype finfun finset fingraph finmap.
-From mathcomp.tarjan Require Import extra acyclic Kosaraju acyclic_tsorted. 
+From mathcomp.tarjan Require Import extra acyclic kosaraju acyclic_tsorted. 
 From eventstruct Require Import utils relalg inhtype ident lposet.
 
 (******************************************************************************)


### PR DESCRIPTION
Several auxiliary definitions and lemmas for pomsets. 

* `lFsPreposet.Build.build` to build `lfspreposet` from finite graph (labeling function and covering relation/Hasse diagram)
* `lfsp_tseq` --- topological sorting of poset
* `lfsp_idx` --- index of event in topological sorting 
* `lfsp_event` --- get event by its index
* `lfsposet_eqP` --- reflect lemma for equality over lposets
* `choiceType` and `countType` instances for `lfspreposet`, `lfsposet`, `pomset`.
* other minor lemmas