### PR TITLE
Tomset Utils

### DIFF
--- a/theories/common/ident.v
+++ b/theories/common/ident.v
@@ -404,11 +404,11 @@ Context {T : identType}.
 Implicit Types (x : T) (s : seq T).
 
 Lemma ident_leE x y : 
-  x <=^i y = ident_le x y.
+  x <=^i y = (encode x <= encode y). 
 Proof. done. Qed.
 
 Lemma ident_ltE x y : 
-  x <^i y = ident_lt x y.
+  x <^i y = (encode x < encode y).
 Proof. done. Qed.
 
 Lemma fresh0 : 

--- a/theories/common/ident.v
+++ b/theories/common/ident.v
@@ -392,7 +392,6 @@ End Syntax.
 Module Export Theory.
 Section Theory.
 
-
 Lemma foldr_monoid {S : Type} {f : S -> S -> S} {n s1 s2}: 
   associative f ->
   (forall a, f n a = a) ->

--- a/theories/common/ident.v
+++ b/theories/common/ident.v
@@ -33,6 +33,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+Import Order.LTheory.
 Import Order.Theory.
 Import Order.TTheory.
 Open Scope order_scope.
@@ -461,43 +462,42 @@ Qed.
 Import Order.Exports.
 
 Definition fresh_seq : seq T -> T := fun t => 
-  fresh (max_seq (\i0 : T) t).
+  max_seq (\i0 : T) (map fresh t).
 
 Lemma fresh_seq_nil : 
-  fresh_seq [::] = (\i1 : T).
-Proof. by rewrite /fresh_seq fresh0. Qed.
+  fresh_seq [::] = (\i0 : T).
+Proof. by rewrite /fresh_seq /=. Qed.
 
-Lemma fresh_seq0 s : 
-  \i0 <^i fresh_seq s.
-Proof. by rewrite /fresh_seq /ident0 /ident_lt /= /Def.ident_lt !decodeK. Qed.
+(* Lemma fresh_seq0 s :  *)
+(*   \i0 <^i fresh_seq s. *)
+(* Proof. by rewrite /fresh_seq /ident0 /ident_lt /= /Def.ident_lt !decodeK. Qed. *)
 
-Lemma i0_min {x} : \i0 <=^i x.
-Proof. by rewrite /(_ <=^i _)/= /Def.ident_le encode0. Qed.
+(* Lemma i0_min {x} : \i0 <=^i x. *)
+(* Proof. by rewrite /(_ <=^i _)/= /Def.ident_le encode0. Qed. *)
 
-Hint Resolve i0_min : core.
+(* Hint Resolve i0_min : core. *)
 
 Lemma maxx0 x : Order.max x \i0 = x.
-Proof. exact/max_idPl. Qed.
+Proof. exact/max_idPl/le0x. Qed.
 
 Lemma max0x x : Order.max \i0 x = x.
-Proof. exact/max_idPr. Qed.
+Proof. exact/max_idPr/le0x. Qed.
 
 Lemma max_fresh x y: 
   Order.max (fresh x) (fresh y) = fresh (Order.max x y).
-Proof.
-  rewrite ?maxEle -fresh_mon; by case: ifP.
-Qed.
+Proof. rewrite ?maxEle -fresh_mon; by case: ifP. Qed.
 
 Lemma fresh_seq_mem x s : 
   x \in s -> x <^i fresh_seq s.
 Proof. 
   rewrite /fresh_seq.
   elim: s=> [|y {}s IH] => //=.
-  rewrite maxElt ?inE; case: ifP=> /[swap]/orP[/eqP<-|/IH] //.
-  - by move/lt_trans/(_ (fresh_lt _)).
+  rewrite inE maxElt. 
+  case: ifP=> /[swap] /orP[/eqP<-|/IH] //. 
+  - by move=> H; apply/(lt_trans _ H)/fresh_lt.
   - by move: (fresh_lt x).
-  rewrite (ltNge y)=> /[swap]/negbT/[! negbK].
-  by rewrite fresh_mon=> /lt_le_trans/[apply].
+  move=> /[swap]/negbT; rewrite -leNgt.
+  by move=> /[swap]/lt_le_trans; apply. 
 Qed.
 
 Lemma fresh_seq_nmem s : fresh_seq s \notin s.
@@ -512,16 +512,18 @@ Proof.
   rewrite in_nfresh /(_ <=^i _) /= /Def.ident_le encode_iter; lia.
 Qed.
 
-Lemma fresh_seq_subset s1 s2: 
+Lemma fresh_seq_subset s1 s2 : 
   {subset s1 <= s2} -> fresh_seq s1 <=^i fresh_seq s2.
 Proof.
-  rewrite /fresh_seq -fresh_mon; elim: s1 s2=> //=a s1 IH s2 s.
+  rewrite /fresh_seq. 
+  elim: s1 s2=> [??|] //=; first exact/le0x. 
+  move=> a s1 IH s2 subs.
   rewrite le_maxl; apply/andP; split.
   - exact/max_seq_in_le/(s a)/mem_head.
   by apply/IH=> ? I; apply/s; rewrite inE I orbT.
 Qed.
 
-Lemma fresh_seq_eq s1 s2: 
+Lemma fresh_seq_eq s1 s2 : 
   s1 =i s2 -> fresh_seq s1 = fresh_seq s2.
 Proof. by move=> eqm; rewrite /fresh_seq (max_set_eq _ eqm). Qed.
 
@@ -529,8 +531,8 @@ Lemma fresh_seqU (s1 s2 : {fset T}):
   fresh_seq (s1 `|` s2)%fset = Order.max (fresh_seq s1) (fresh_seq s2).
 Proof.
   have->: Order.max (fresh_seq s1) (fresh_seq s2) = fresh_seq (s1 ++ s2).
-  - apply/eqP; rewrite max_fresh /fresh_seq (inj_eq fresh_inj).
-    exact/eqP/(foldr_monoid maxA max0x maxx0).
+  - apply/eqP; rewrite /fresh_seq /=.
+    by rewrite (foldr_monoid maxA max0x maxx0) ?map_cat. 
   have/andP/(le_anti) //: 
     ((fresh_seq (s1 `|` s2)%fset <=^i fresh_seq (s1 ++ s2)) /\ 
     (fresh_seq (s1 ++ s2) <=^i fresh_seq (s1 `|` s2)%fset)).
@@ -544,7 +546,6 @@ Proof.
   under (@fresh_seq_eq _ [:: x]) do rewrite ?inE //.
   by rewrite {1}/fresh_seq /= maxx0.
 Qed.
-
 
 End Theory.
 End Theory.

--- a/theories/common/ident.v
+++ b/theories/common/ident.v
@@ -403,6 +403,14 @@ Proof. by move=> A L R; elim: s1=> //= ??; rewrite -A=>->. Qed.
 Context {T : identType}.
 Implicit Types (x : T) (s : seq T).
 
+Lemma ident_leE x y : 
+  x <=^i y = ident_le x y.
+Proof. done. Qed.
+
+Lemma ident_ltE x y : 
+  x <^i y = ident_lt x y.
+Proof. done. Qed.
+
 Lemma fresh0 : 
   fresh (\i0 : T) = \i1.
 Proof. by rewrite /fresh encode0. Qed.
@@ -458,23 +466,12 @@ Proof.
   move=>->; rewrite encode_fresh -(inj_eq encode_inj); lia.
 Qed.
 
-Import Order.Exports.
-
 Definition fresh_seq : seq T -> T := fun t => 
   max_seq (\i0 : T) (map fresh t).
 
 Lemma fresh_seq_nil : 
   fresh_seq [::] = (\i0 : T).
 Proof. by rewrite /fresh_seq /=. Qed.
-
-(* Lemma fresh_seq0 s :  *)
-(*   \i0 <^i fresh_seq s. *)
-(* Proof. by rewrite /fresh_seq /ident0 /ident_lt /= /Def.ident_lt !decodeK. Qed. *)
-
-(* Lemma i0_min {x} : \i0 <=^i x. *)
-(* Proof. by rewrite /(_ <=^i _)/= /Def.ident_le encode0. Qed. *)
-
-(* Hint Resolve i0_min : core. *)
 
 Lemma maxx0 x : Order.max x \i0 = x.
 Proof. exact/max_idPl/le0x. Qed.

--- a/theories/common/order.v
+++ b/theories/common/order.v
@@ -17,6 +17,29 @@ Local Open Scope order_scope.
 (*                                                                            *)
 (******************************************************************************)
 
+Section POrderUtils. 
+Context {disp : unit} {T : porderType disp}.
+Implicit Types (x y z : T).
+
+Lemma le_ge_incomp x y : 
+  [|| (x <= y), (x >= y) | (x >< y)].
+Proof. 
+  case: (x <= y)/idP=> //=.
+  case: (y <= x)/idP=> //=.
+  rewrite !negb_or=> /negP ? /negP ?; exact/andP.
+Qed.
+
+Lemma le_gt_incomp x y : 
+  [|| (x <= y), (x > y) | (x >< y)].
+Proof. 
+  move: (le_ge_incomp x y)=> /or3P[->||->] //.
+  rewrite le_eqVlt=> /orP[/eqP->|->] //.
+  by rewrite le_refl.
+Qed.
+
+End POrderUtils.
+
+
 Module Export MaxSup.
 Section Def.
 Context {disp : unit} {T : porderType disp}.

--- a/theories/common/order.v
+++ b/theories/common/order.v
@@ -43,7 +43,7 @@ End POrderUtils.
 Module Export MaxSup.
 Section Def.
 Context {disp : unit} {T : porderType disp}.
-Implicit Type (s : seq T) (x : T).
+Implicit Types (s : seq T) (x : T).
 
 (* TODO: generalize to arbitary pred? *)
 Definition is_sup s x := 
@@ -60,7 +60,7 @@ End Def.
 
 Section Theory.
 Context {disp : unit} {T : orderType disp}.
-Implicit Type (s : seq T) (x : T).
+Implicit Types (s : seq T) (x : T).
 
 Lemma is_supP s x : 
   reflect (x \in s /\ {in s, forall y, y <= x}) (is_sup s x).
@@ -95,7 +95,7 @@ Lemma is_sup1 x y :
 Proof.
   rewrite /is_sup inE /= andbT andb_idr eq_sym //.
   by move=> /eqP->; rewrite lexx.
-Qed.
+Qed.    
 
 Lemma max_seq_in d s : 
   max_seq d s \in d :: s.
@@ -203,6 +203,22 @@ Proof.
 Qed.
 
 End WithBottom.
+
+Section Monotone.
+Variables (f : T -> T) (s : seq T) (x : T).
+
+Hypothesis (finj : injective f).
+Hypothesis (fmon : {mono f : x y / x <= y}).
+
+Lemma is_sup_mon : 
+  is_sup [seq f y | y <- s] (f x) = is_sup s x.
+Proof. 
+  rewrite /is_sup mem_map // all_map.
+  apply/andb_id2l=> _; apply/eq_all.
+  move=> y /=; exact/fmon. 
+Qed.
+
+End Monotone.
 
 End Theory.
 

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -327,11 +327,19 @@ Qed.
 End FoldUtils. 
 
 Section FSetUtils.
-Context {T U : choiceType}.
+Context {key : unit} {T U : choiceType}.
 Implicit Types (s : {fset T}) (p : pred T) (r : rel T).
 Implicit Types (f : T -> U).
 
 Local Open Scope fset_scope.
+
+Lemma in_fset1 (x : T) a :
+  (a \in [fset[key] x in [:: x]]) = (a == x).
+Proof. by rewrite !mem_imfset //= inE. Qed.
+
+Lemma fset_singl (x : T) : 
+  [fset[key] x in [:: x]] = [fset x].
+Proof. by apply/fsetP=> y; rewrite in_fset1 inE. Qed.
 
 Lemma imfset1 f x : 
   f @` ([fset x]) = [fset (f x)].

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -1237,46 +1237,54 @@ Qed.
 
 End FindNthMkMask.
 
-Section MaskMkMask.
-Context {T : Type} {x : T}. (* {n m : nat} *)
-(* Variables (t : n.-tuple T) (u : m.-tuple T) (f : 'I_n -> 'I_m).  *)
-Variables (t u : seq T).
-Variables (f : nat -> nat).
+Section MkMaskMask.
+Context {T : Type} {n m : nat}.
+Variables (t : n.-tuple T) (u : m.-tuple T) (f : 'I_n -> 'I_m).
+Let s := mkseq (sub_lift (addn m) f) n.
 
-Let n := size t.
-Let m := size u.
-Let s := mkseq f n.
-Let D := iota 0 n.
-(* Let D := ltn^~ n : pred nat. *)
+Hypothesis (Hhm  : {homo f : x y / x < y}).
+Hypothesis (Hinj : injective f).
+Hypothesis (Hnm  : forall i, f i < m).
+Hypothesis (Hnth : forall i, tnth t i = tnth u (f i)).
 
-Hypothesis (le_nm : n <= m).
-Hypothesis (Hhm   : { in D &, {homo f : x y / x < y}}).
-Hypothesis (Hinj  : { in D &, injective f}).
-Hypothesis (Hnm   : { in D, forall i, f i < m}).
-Hypothesis (Hnth  : { in D, forall i, nth x t i = nth x u (f i)}).
-
-Lemma mask_mkmask :
+Lemma mkmask_mask :
   mask (mkmask s m) u = t.
 Proof. 
-  have all_lt: all (fun i : nat => i < m) s.
+  (* move=> Hfh Hf Hm Hn. *)
+  have Ha: all (fun i : nat => i < m) s.
   - apply/allP=> i /(nthP 0) [j]. 
-    rewrite size_mkseq=> Hj <-. 
-    rewrite nth_mkseq //; apply/Hnm. 
-    by rewrite mem_iota.
-  have szmE : size (mkmask s m) = m.
-  - by rewrite size_mkmask ?size_nseq // all_map /=.
-  have szE: size (mask (mkmask s m) u) = n.
-  - rewrite size_mask ?szmE ?count_mkmask ?size_mkseq //.
-    by apply/mkseq_in_uniq.
-  apply/(@eq_from_nth _ x)=> //.
-  rewrite szE=> i Hi.
-  rewrite nth_mask ?find_nth_mkmask=> //.
-  - by subst s; rewrite nth_mkseq ?Hnth ?mem_iota //. 
-  - by apply/homo_sorted_in; [exact/Hhm | | exact/iota_ltn_sorted]. 
-  by rewrite size_mkseq; apply/andP. 
+    rewrite size_mkseq=> Hj <-.
+    by rewrite nth_mkseq // sub_liftT.
+  have Hsz: size (mask (mkmask s m) u) = size t.
+  - rewrite size_mask ?size_mkmask ?count_mkmask ?size_tuple //.
+    apply/mkseq_uniq/sub_lift_inj.
+    + by move=> {}x {}y; move: (valP (f y))=> /[swap] /= <-; lia.
+    + by move=> ??; apply/addnI. 
+    by move=> ???; apply/Hinj/val_inj. 
+  have Hsz': size (mask (mkmask s m) u) = n.
+  - by rewrite Hsz size_tuple.
+  apply/(@eq_from_tuple _ _ _ Hsz).
+  rewrite tvalK; apply/eq_from_tnth.
+  move=> i; rewrite tcastE /tnth /=.
+  have Hi: i < n by move: i=> []; rewrite size_tuple.
+  rewrite nth_mask ?find_nth_mkmask=> //; last first.
+  - by rewrite size_mkmask ?size_tuple //.
+  - rewrite size_mkseq; apply/andP; split=> //.
+    move: Hinj Hi=> /leq_card /=. 
+    by rewrite !card_ord.
+  - apply/homo_sorted; last by exact/iota_ltn_sorted.
+    apply/sub_lift_homo=> //=; [lia| ..]; last first.
+    + by move=> ?? /=; rewrite ltn_add2l.
+    move=> {}x {}y /= /negP; rewrite -leqNgt=> Hyn.
+    rewrite -[val (f x)]addn0 -addnS; apply/leq_add. 
+    - by apply/ltnW; move: (valP (f x)). 
+   apply/(leq_trans _ Hyn); lia.
+  rewrite -tnth_nth tcastE esymK Hnth. 
+  have ->: cast_ord (size_tuple t) i = Ordinal Hi by exact/val_inj.
+  by subst s; rewrite nth_mkseq // sub_liftT // -tnth_nth.
 Qed.
 
-End MaskMkMask.
+End MkMaskMask.
 
 Module Export SubFinFun.
 

--- a/theories/concur/lposet.v
+++ b/theories/concur/lposet.v
@@ -2059,68 +2059,68 @@ End Iso.
 Section HomP. 
 Context {L : eqType} {n m : nat} (t : n.-tuple L) (u : m.-tuple L).
 
-Lemma homP : 
-  reflect ?|{ihom eventType t -> eventType u}| (subseq t u).
-Proof. 
-  apply/(iffP idP); last first.
-  - move=> [f]; apply/subseqP.
-    pose g := sub_lift (fun i => (m + i)%N) (fun i => val (f i)) : nat -> nat.  
-    pose s := mkseq g n.
-    exists (mkmask s m).
-    + rewrite size_mkmask ?size_nseq ?size_tuple // all_map /=.
-      subst g=> /=; apply/allP=> i /=.
-      rewrite mem_iota addnC addn0=> /andP[??]. 
-      by rewrite sub_liftT.
-    apply/esym; subst s. 
-    rewrite (@mkmask_mask L _ _ t)=> //.
-    + by move=> ???; apply (sca_monotone f).
-    + exact/ihom_inj.
-    by move=> ?; rewrite -tlabE -tlabE lab_preserving.
-  move: m u; clear m u.
-  case=> [u|m u].
-  - move: (tuple0 u)=> /= -> /=.
-    rewrite -size_eq0 size_tuple=> /eqP Hn.
-    have efalse: (forall e : eventType t, False).
-    + by rewrite /eventType /= Hn => [[i]]; rewrite ltn0. 
-    have f: ({hom eventType t -> eventType ([tuple] : 0.-tuple L)}).
-    + by exists (fun e => match efalse e with end).
-    constructor; exists f; repeat constructor; by move=> ?. 
-  move=> /subseqP=> [[b Hsz Hb]].
-  pose g := (fun => ord_max) : eventType t -> eventType u.
-  pose f := sub_down g (find_nth id b).
-  pose l := (@lab L (eventType u) ord_max) : L.
-  have He: forall (e : eventType t), (find_nth id b e < m.+1)%N.
-  - move=> e; rewrite -[m.+1](size_tuple u) -Hsz.
-    by rewrite (mask_size_find_nth Hsz) // -Hb (size_tuple t).
-  constructor; unshelve eexists; [exact/f |]. 
-  repeat constructor; move=>/=.
-  - move=> e; rewrite !tlabE. 
-    rewrite !(tnth_nth l) Hb (nth_mask l e Hsz).
-    by rewrite val_sub_downT //. 
-  - move=> e1 e2; rewrite !tleE !val_sub_downT //; exact/find_nth_leq.
-  move=> e1 e2=> /=; subst f.
-  apply/sub_down_inj_inT; rewrite ?/in_mem //=.
-  by move=>?? /find_nth_inj/val_inj. 
-Qed.
+(* Lemma homP :  *)
+(*   reflect ?|{ihom eventType t -> eventType u}| (subseq t u). *)
+(* Proof.  *)
+(*   apply/(iffP idP); last first. *)
+(*   - move=> [f]; apply/subseqP. *)
+(*     pose g := sub_lift (fun i => (m + i)%N) (fun i => val (f i)) : nat -> nat.   *)
+(*     pose s := mkseq g n. *)
+(*     exists (mkmask s m). *)
+(*     + rewrite size_mkmask ?size_nseq ?size_tuple // all_map /=. *)
+(*       subst g=> /=; apply/allP=> i /=. *)
+(*       rewrite mem_iota addnC addn0=> /andP[??].  *)
+(*       by rewrite sub_liftT. *)
+(*     apply/esym; subst s.  *)
+(*     rewrite (@mkmask_mask L _ _ t)=> //. *)
+(*     + by move=> ???; apply (sca_monotone f). *)
+(*     + exact/ihom_inj. *)
+(*     by move=> ?; rewrite -tlabE -tlabE lab_preserving. *)
+(*   move: m u; clear m u. *)
+(*   case=> [u|m u]. *)
+(*   - move: (tuple0 u)=> /= -> /=. *)
+(*     rewrite -size_eq0 size_tuple=> /eqP Hn. *)
+(*     have efalse: (forall e : eventType t, False). *)
+(*     + by rewrite /eventType /= Hn => [[i]]; rewrite ltn0.  *)
+(*     have f: ({hom eventType t -> eventType ([tuple] : 0.-tuple L)}). *)
+(*     + by exists (fun e => match efalse e with end). *)
+(*     constructor; exists f; repeat constructor; by move=> ?.  *)
+(*   move=> /subseqP=> [[b Hsz Hb]]. *)
+(*   pose g := (fun => ord_max) : eventType t -> eventType u. *)
+(*   pose f := sub_down g (find_nth id b). *)
+(*   pose l := (@lab L (eventType u) ord_max) : L. *)
+(*   have He: forall (e : eventType t), (find_nth id b e < m.+1)%N. *)
+(*   - move=> e; rewrite -[m.+1](size_tuple u) -Hsz. *)
+(*     by rewrite (mask_size_find_nth Hsz) // -Hb (size_tuple t). *)
+(*   constructor; unshelve eexists; [exact/f |].  *)
+(*   repeat constructor; move=>/=. *)
+(*   - move=> e; rewrite !tlabE.  *)
+(*     rewrite !(tnth_nth l) Hb (nth_mask l e Hsz). *)
+(*     by rewrite val_sub_downT //.  *)
+(*   - move=> e1 e2; rewrite !tleE !val_sub_downT //; exact/find_nth_leq. *)
+(*   move=> e1 e2=> /=; subst f. *)
+(*   apply/sub_down_inj_inT; rewrite ?/in_mem //=. *)
+(*   by move=>?? /find_nth_inj/val_inj.  *)
+(* Qed. *)
 
 End HomP.
 
 Section IsoP.
 Context {L : eqType} {n m : nat} (t : n.-tuple L) (u : m.-tuple L).
 
-Lemma isoP : 
-  reflect ?|{iso eventType t -> eventType u}| (t == u :> seq L).
-Proof. 
-  apply/(iffP idP); last first.  
-  - move=> [f]; move: (lPoset.Iso.Build.inv f)=> g.
-    apply/eqP/subseq_anti/andP. 
-    split; apply/homP; eexists; [exact/f | exact/g]. 
-  move=> /eqP H; have Hn: n = m. 
-  - by rewrite -(size_tuple t) -(size_tuple u) H.
-  move: u H; clear u; case Hn=> u.
-  move=> /val_inj ->.
-  constructor; exact/[iso of idfun]. 
-Qed.
+(* Lemma isoP :  *)
+(*   reflect ?|{iso eventType t -> eventType u}| (t == u :> seq L). *)
+(* Proof.  *)
+(*   apply/(iffP idP); last first.   *)
+(*   - move=> [f]; move: (lPoset.Iso.Build.inv f)=> g. *)
+(*     apply/eqP/subseq_anti/andP.  *)
+(*     split; apply/homP; eexists; [exact/f | exact/g].  *)
+(*   move=> /eqP H; have Hn: n = m.  *)
+(*   - by rewrite -(size_tuple t) -(size_tuple u) H. *)
+(*   move: u H; clear u; case Hn=> u. *)
+(*   move=> /val_inj ->. *)
+(*   constructor; exact/[iso of idfun].  *)
+(* Qed. *)
 
 End IsoP. 
 

--- a/theories/concur/lposet.v
+++ b/theories/concur/lposet.v
@@ -2059,68 +2059,68 @@ End Iso.
 Section HomP. 
 Context {L : eqType} {n m : nat} (t : n.-tuple L) (u : m.-tuple L).
 
-(* Lemma homP :  *)
-(*   reflect ?|{ihom eventType t -> eventType u}| (subseq t u). *)
-(* Proof.  *)
-(*   apply/(iffP idP); last first. *)
-(*   - move=> [f]; apply/subseqP. *)
-(*     pose g := sub_lift (fun i => (m + i)%N) (fun i => val (f i)) : nat -> nat.   *)
-(*     pose s := mkseq g n. *)
-(*     exists (mkmask s m). *)
-(*     + rewrite size_mkmask ?size_nseq ?size_tuple // all_map /=. *)
-(*       subst g=> /=; apply/allP=> i /=. *)
-(*       rewrite mem_iota addnC addn0=> /andP[??].  *)
-(*       by rewrite sub_liftT. *)
-(*     apply/esym; subst s.  *)
-(*     rewrite (@mkmask_mask L _ _ t)=> //. *)
-(*     + by move=> ???; apply (sca_monotone f). *)
-(*     + exact/ihom_inj. *)
-(*     by move=> ?; rewrite -tlabE -tlabE lab_preserving. *)
-(*   move: m u; clear m u. *)
-(*   case=> [u|m u]. *)
-(*   - move: (tuple0 u)=> /= -> /=. *)
-(*     rewrite -size_eq0 size_tuple=> /eqP Hn. *)
-(*     have efalse: (forall e : eventType t, False). *)
-(*     + by rewrite /eventType /= Hn => [[i]]; rewrite ltn0.  *)
-(*     have f: ({hom eventType t -> eventType ([tuple] : 0.-tuple L)}). *)
-(*     + by exists (fun e => match efalse e with end). *)
-(*     constructor; exists f; repeat constructor; by move=> ?.  *)
-(*   move=> /subseqP=> [[b Hsz Hb]]. *)
-(*   pose g := (fun => ord_max) : eventType t -> eventType u. *)
-(*   pose f := sub_down g (find_nth id b). *)
-(*   pose l := (@lab L (eventType u) ord_max) : L. *)
-(*   have He: forall (e : eventType t), (find_nth id b e < m.+1)%N. *)
-(*   - move=> e; rewrite -[m.+1](size_tuple u) -Hsz. *)
-(*     by rewrite (mask_size_find_nth Hsz) // -Hb (size_tuple t). *)
-(*   constructor; unshelve eexists; [exact/f |].  *)
-(*   repeat constructor; move=>/=. *)
-(*   - move=> e; rewrite !tlabE.  *)
-(*     rewrite !(tnth_nth l) Hb (nth_mask l e Hsz). *)
-(*     by rewrite val_sub_downT //.  *)
-(*   - move=> e1 e2; rewrite !tleE !val_sub_downT //; exact/find_nth_leq. *)
-(*   move=> e1 e2=> /=; subst f. *)
-(*   apply/sub_down_inj_inT; rewrite ?/in_mem //=. *)
-(*   by move=>?? /find_nth_inj/val_inj.  *)
-(* Qed. *)
+Lemma homP :
+  reflect ?|{ihom eventType t -> eventType u}| (subseq t u).
+Proof.
+  apply/(iffP idP); last first.
+  - move=> [f]; apply/subseqP.
+    pose g := sub_lift (fun i => (m + i)%N) (fun i => val (f i)) : nat -> nat.
+    pose s := mkseq g n.
+    exists (mkmask s m).
+    + rewrite size_mkmask ?size_nseq ?size_tuple // all_map /=.
+      subst g=> /=; apply/allP=> i /=.
+      rewrite mem_iota addnC addn0=> /andP[??].
+      by rewrite sub_liftT.
+    apply/esym; subst s.
+    rewrite (@mkmask_mask L _ _ t)=> //.
+    + by move=> ???; apply (sca_monotone f).
+    + exact/ihom_inj.
+    by move=> ?; rewrite -tlabE -tlabE lab_preserving.
+  move: m u; clear m u.
+  case=> [u|m u].
+  - move: (tuple0 u)=> /= -> /=.
+    rewrite -size_eq0 size_tuple=> /eqP Hn.
+    have efalse: (forall e : eventType t, False).
+    + by rewrite /eventType /= Hn => [[i]]; rewrite ltn0.
+    have f: ({hom eventType t -> eventType ([tuple] : 0.-tuple L)}).
+    + by exists (fun e => match efalse e with end).
+    constructor; exists f; repeat constructor; by move=> ?.
+  move=> /subseqP=> [[b Hsz Hb]].
+  pose g := (fun => ord_max) : eventType t -> eventType u.
+  pose f := sub_down g (find_nth id b).
+  pose l := (@lab L (eventType u) ord_max) : L.
+  have He: forall (e : eventType t), (find_nth id b e < m.+1)%N.
+  - move=> e; rewrite -[m.+1](size_tuple u) -Hsz.
+    by rewrite (mask_size_find_nth Hsz) // -Hb (size_tuple t).
+  constructor; unshelve eexists; [exact/f |].
+  repeat constructor; move=>/=.
+  - move=> e; rewrite !tlabE.
+    rewrite !(tnth_nth l) Hb (nth_mask l e Hsz).
+    by rewrite val_sub_downT //.
+  - move=> e1 e2; rewrite !tleE !val_sub_downT //; exact/find_nth_leq.
+  move=> e1 e2=> /=; subst f.
+  apply/sub_down_inj_inT; rewrite ?/in_mem //=.
+  by move=>?? /find_nth_inj/val_inj.
+Qed.
 
 End HomP.
 
 Section IsoP.
 Context {L : eqType} {n m : nat} (t : n.-tuple L) (u : m.-tuple L).
 
-(* Lemma isoP :  *)
-(*   reflect ?|{iso eventType t -> eventType u}| (t == u :> seq L). *)
-(* Proof.  *)
-(*   apply/(iffP idP); last first.   *)
-(*   - move=> [f]; move: (lPoset.Iso.Build.inv f)=> g. *)
-(*     apply/eqP/subseq_anti/andP.  *)
-(*     split; apply/homP; eexists; [exact/f | exact/g].  *)
-(*   move=> /eqP H; have Hn: n = m.  *)
-(*   - by rewrite -(size_tuple t) -(size_tuple u) H. *)
-(*   move: u H; clear u; case Hn=> u. *)
-(*   move=> /val_inj ->. *)
-(*   constructor; exact/[iso of idfun].  *)
-(* Qed. *)
+Lemma isoP :
+  reflect ?|{iso eventType t -> eventType u}| (t == u :> seq L).
+Proof.
+  apply/(iffP idP); last first.
+  - move=> [f]; move: (lPoset.Iso.Build.inv f)=> g.
+    apply/eqP/subseq_anti/andP.
+    split; apply/homP; eexists; [exact/f | exact/g].
+  move=> /eqP H; have Hn: n = m.
+  - by rewrite -(size_tuple t) -(size_tuple u) H.
+  move: u H; clear u; case Hn=> u.
+  move=> /val_inj ->.
+  constructor; exact/[iso of idfun].
+Qed.
 
 End IsoP. 
 

--- a/theories/concur/lposet.v
+++ b/theories/concur/lposet.v
@@ -242,6 +242,13 @@ Lemma ca_monotone f :
   { homo f : e1 e2 / e1 <= e2 }.
 Proof. by case: f => ? [[]]. Qed.
 
+Lemma sca_monotone_in f (D : pred E1) :
+  {in D &, injective f} -> {in D &, { homo f : e1 e2 / e1 < e2 }}.
+Proof. 
+  move=> ?; apply/inj_homo_lt_in=> //.
+  move=> ????; exact/ca_monotone.
+Qed.
+
 Lemma sca_img f e1 e2 : (f e1 < f e2) -> (e1 < e2) || (e1 >< e2).
 Proof.
   case H: (e1 < e2)=> //= Hf.
@@ -436,8 +443,8 @@ End Exports.
 
 End Build.
 
-
 End iHom.
+
 
 Module Export bHom.
 
@@ -714,6 +721,15 @@ Proof.
   by case: f=> ? [[? []]] => /= /[apply]. 
 Qed.
 
+Lemma sca_reflecting :
+  { mono f : e1 e2 / e1 < e2 }.
+Proof.
+  move=> e1 e2; apply/idP/idP; last exact/(sca_monotone f).
+  rewrite !lt_def ca_reflecting=> /andP[] neq ->.
+  rewrite andbT; apply/negP=> /eqP. 
+  by move: neq=> /[swap] ->; rewrite eq_refl.
+Qed.
+
 End Theory.
 End Theory.
 
@@ -943,6 +959,9 @@ Definition homType  := Hom.Pack class.
 Definition bhomType := bHom.Pack class.
 Definition embType  := Emb.Pack (Emb.Class class (mixin class)).
 
+(* TODO: perhaps ihomType instance is defined incorretly *)
+Definition ihomType := bHom.ihomType bhomType.
+
 Lemma prefMixin : Pref.mixin_of cT.
 Proof.
   case: cT=> f [[? [g *]]] /=.
@@ -963,10 +982,12 @@ Coercion base : class_of >-> bHom.class_of.
 Coercion mixin : class_of >-> Emb.mixin_of.
 Coercion apply : type >-> Funclass.
 Coercion homType  : type >-> Hom.type.
+Coercion ihomType : type >-> iHom.type.
 Coercion bhomType : type >-> bHom.type.
 Coercion embType  : type >-> Emb.type.
 Coercion prefType  : type >-> Pref.type.
 Canonical homType.
+Canonical ihomType.
 Canonical bhomType.
 Canonical embType.
 Canonical prefType.
@@ -983,6 +1004,20 @@ Notation "[ 'iso' 'of' f ]" :=
   (Iso.mk (fun hCls => @Iso.Pack _ _ _ f hCls))
   (at level 0, format "[ 'iso'  'of'  f ]") : lposet_scope.
 End Syntax. 
+
+Module Export Theory.
+Section Theory. 
+Context {L : Type} {E1 E2 : eventType L} (f : {iso  E1 -> E2}).
+
+Lemma ca_incomp_reflecting :
+  { mono f : e1 e2 / e1 >< e2 }.
+Proof.
+  move=> e1 e2; apply: negbLR. 
+  by rewrite !negbK /comparable !(ca_reflecting f).
+Qed.
+
+End Theory.
+End Theory.
 
 Module Build.
 Section Build.
@@ -1309,6 +1344,7 @@ Export lPoset.iHom.Theory.
 Export lPoset.bHom.Theory.
 Export lPoset.Emb.Theory.
 Export lPoset.Pref.Theory.
+Export lPoset.Iso.Theory.
 
 Export lPoset.Ext.Theory.
 

--- a/theories/concur/lts.v
+++ b/theories/concur/lts.v
@@ -882,7 +882,7 @@ Proof.
   rewrite -E; apply/IHt; by case: (t) pf.
 Qed.
 
-Lemma invariant_trace_lan p s tr : 
+Lemma invariant_trace_lang p s tr : 
   invariant p -> tr \in trace_lang s -> p s -> p (lst_state s tr).
 Proof.
   by move/trace_invariant=> /(_ s tr)/[swap]/eqP<-/[apply].

--- a/theories/concur/lts.v
+++ b/theories/concur/lts.v
@@ -699,6 +699,11 @@ Lemma fst_state_rcons s ts st :
   fst_state s (rcons ts st) = src (head st ts).
 Proof. by case: ts. Qed.
 
+(* TODO: rename to avoid confusion with belast from seq.v ? *)
+Lemma fst_state_rcons_belast s ts st :
+  fst_state s (rcons ts st) = s -> fst_state s ts = s.
+Proof. by case: ts. Qed.
+
 Lemma fst_stateNnil s s' ts : ts <> [::] ->
   fst_state s' ts = fst_state s ts.
 Proof. by case: ts. Qed.
@@ -748,6 +753,18 @@ Proof. by case: ts=> //=; rewrite /adjoint eq_refl. Qed.
 Lemma adjoint_lastE ts st : 
   adjoint ts [:: st] = (lst_state (src st) ts == src st).
 Proof. done. Qed.
+
+(* TODO: refactor, use trace_lang? *)
+Lemma fst_state_rcons_adj s ts st : 
+  s = fst_state s (rcons ts st) -> adjoint ts [:: st] -> 
+  s = fst_state s ts.
+Proof. by rewrite fst_state_rcons adjoint_lastE; case: ts=> //= ??? /eqP. Qed.
+
+(* TODO: refactor, use trace_lang? *)
+Lemma lst_state_rcons_adj s ts st : 
+  s = fst_state s (rcons ts st) -> adjoint ts [:: st] -> 
+  lst_state s ts = src st.
+Proof. by rewrite fst_state_rcons adjoint_lastE; case: ts=> //= ??? /eqP. Qed.
 
 Lemma is_trace_cons st ts : 
   is_trace (st :: ts) = [&& is_step st, is_trace ts & adjoint [:: st] ts].
@@ -833,7 +850,6 @@ Proof. exact/eqxx. Qed.
 
 Lemma lts_lang0 s : lts_lang s [::].
 Proof. (exists [trace])=> //; exact/trace_lang0. Qed.
-
 
 Section Measure.
 Context {M : Type}.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -2743,7 +2743,77 @@ Module Export Theory.
 Section Theory.
 Context {E : identType} {L : choiceType}.
 Variable (bot : L).
-Implicit Types (t : tomset E L bot).
+Implicit Types (t u : tomset E L bot).
+
+Lemma tomset_ihomE lt lu : 
+  let t := @of_seq E L bot lt in
+  let u := @of_seq E L bot lu in
+  ihom_le t u = subseq lu lt.
+Proof. 
+  rewrite /of_seq /Pomset.of_seq piE /=.
+  pose t := lFsPoset.of_seq E L bot lt. 
+  pose u := lFsPoset.of_seq E L bot lu. 
+  apply/idP/idP; first last.
+  - admit.
+  rewrite /of_seq /=.
+  move=> /ihom_leP [f] finj; apply/subseqP.
+  pose n := size lu.
+  pose m := size lt.
+  pose g : nat -> nat := fun i => encode (f (decode i)).
+  pose s := mkseq g n.
+  exists (mkmask s m)=> //.
+  - admit. (* rewrite size_mkmask ?size_nseq // all_map /=. *)
+  rewrite (@mask_mkmask _ bot)=> //.
+  - admit.
+  - rewrite /g=> /= i j. 
+    rewrite !mem_iota !add0n /=. 
+    move=> Hi Hj Hij.
+    apply/(@operational_sca E L bot t).
+    + exact/(lfsp_supp_closed t).
+    + exact/(lfsp_acyclic t).
+    + exact/lFsPoset.of_seq_operational.
+    rewrite -fs_scaE.
+    apply/sca_monotone_in=> /=. 
+    + exact/finj.
+    + admit.
+    + admit.
+      admit.
+  - move=> /= i j; rewrite !mem_iota !add0n /g /= => Hi Hj.
+    move=> /encode_inj/finj=> dinj.
+    apply/decode_inj/dinj.
+    
+    move=> 
+    admit.
+  - admit.
+  move=> /= i Hi; rewrite /g.
+  rewrite -lFsPrePoset.of_seq_labE.
+
+
+(* TODO: use notation for ihom_le *)
+Lemma tomset_ihomE t u : 
+  ihom_le t u = subseq (lfsp_labels u) (lfsp_labels t).
+Proof. 
+  apply/idP/idP.
+  - move=> /ihom_leP [f] finj; apply/subseqP.
+    pose n := fs_size u.
+    pose m := fs_size t.
+    pose g : nat -> nat := fun i => 
+      (* TODO: set default for lfsp_event to fresh_seq? *)
+      let e := lfsp_event u (fresh_seq (finsupp u)) i in 
+      lfsp_idx t (f e).
+    pose s := mkseq g n.
+    exists (mkmask s m).
+    + rewrite size_mkmask ?size_nseq ?size_tuple // all_map /=.
+      subst g=> /=; apply/allP=> i /=.
+      rewrite mem_iota addnC addn0=> /andP[??]. 
+      by rewrite sub_liftT.
+    apply/esym; subst s. 
+    rewrite (@mkmask_mask L _ _ t)=> //.
+    + by move=> ???; apply (sca_monotone f).
+    + exact/ihom_inj.
+    by move=> ?; rewrite -tlabE -tlabE lab_preserving.
+  
+
 
 (* Lemma tomset_labelsK : 
   cancel (@lfsp_labels E L bot) (@lFsPrePoset.of_seq E L bot).

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -119,6 +119,9 @@ Definition fs_ca p : rel E :=
 Definition fs_sca p : rel E := 
   fun e1 e2 => (e2 != e1) && (fs_ca p e1 e2).
 
+(* TODO: rename lfsp_size? *)
+Definition fs_size p : nat := #|` finsupp p|.
+
 Definition lab_defined p := 
   [forall e : finsupp p, fs_lab p (val e) != bot].
 
@@ -130,6 +133,9 @@ Definition operational p :=
   [forall e1 : finsupp p, forall e2 : finsupp p, 
     (fs_ca p (val e1) (val e2)) ==> (val e1 <=^i val e2)
   ].
+
+Definition conseq_num p :=
+  finsupp p == [fset e | e in nfresh \i0 (fs_size p)].
 
 Definition lfsp_tseq p : seq E := 
   map val (tseq (rgraph (@fin_ica p))).
@@ -149,8 +155,6 @@ Definition lfsp_fresh p : E :=
 (* TODO: unify with UpFinPOrder *)
 Definition lfsp_dw_clos p es := 
   [seq e <- finsupp p | [exists e' : es, fs_ca p e (val e')]].
-
-Definition fs_size p : nat := #|` finsupp p|.
 
 End Def.
 
@@ -477,11 +481,16 @@ Lemma fs_ca_ident_le p :
 Proof. move=>?? /operationalP; exact. Qed.
 
 Lemma fs_ica_fin_icaE p : 
-  supp_closed p ->
-  fs_ica p =2 sub_rel_lift (fin_ica p).
+  supp_closed p -> fs_ica p =2 sub_rel_lift (fin_ica p).
 Proof.
   move=> sc>; rewrite /fin_ica sub_rel_lift_downK=> //=>.
   by case/(supp_closedP _ sc)=> /=->.
+
+Lemma conseq_num_mem p e : 
+  conseq_num p -> (e \in finsupp p) = (encode e < fs_size p)%N.
+Proof. 
+  move=> /eqP->; rewrite in_fset /=.
+  by rewrite in_nfresh encode0 addn0 /=. 
 Qed.
 
 End Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -800,8 +800,8 @@ Implicit Types (p : lfspreposet E L bot).
 Implicit Types (ls : seq L).
 
 Definition of_seq ls := 
-  let fE  := [fset e | e in nfresh \i1 (size ls)] in 
-  let lab := fun e : fE => (nth bot (bot :: ls) (encode (val e))) in
+  let fE  := [fset e | e in nfresh \i0 (size ls)] in 
+  let lab := fun e : fE => (nth bot ls (encode (val e))) in
   let ca  := fun e1 e2 : E => e1 <=^i e2 in
   @build_cov E L bot fE lab ca.
 
@@ -809,17 +809,17 @@ Variable (ls : seq L).
 Hypothesis (lsD : bot \notin ls).
 
 Lemma of_seq_nth_defined : 
-  forall (e : [fset e | e in nfresh \i1 (size ls)]),
-    nth bot (bot :: ls) (@encode E (val e)) != bot.
+  forall (e : [fset e | e in nfresh \i0 (size ls)]),
+    nth bot ls (@encode E (val e)) != bot.
 Proof.
-  move: lsD=> /negP nbl [/= ?].
-  rewrite ?inE /= in_nfresh encode1; case: (encode _)=> //> ?.
-  apply/negP; move: nbl=> /[swap]/eqP<-.
-  apply; apply/mem_nth; lia.
+  move: lsD=> /negP nbl [/= e].
+  rewrite ?inE /= in_nfresh encode0 addn0 /= => He.
+  apply/negP; move: nbl=> /[swap]/eqP<-.  
+  apply; exact/mem_nth.
 Qed.
 
 Lemma of_seq_finsupp : 
-  finsupp (of_seq ls) = [fset e | e in nfresh \i1 (size ls)].
+  finsupp (of_seq ls) = [fset e | e in nfresh \i0 (size ls)].
 Proof. rewrite build_finsupp //; exact/of_seq_nth_defined. Qed.
 
 Lemma of_seq_fresh :
@@ -843,15 +843,14 @@ Proof.
 Qed.
 
 Lemma of_seq_labE e : 
-  fs_lab (of_seq ls) e = nth bot (bot :: ls) (encode e).
+  fs_lab (of_seq ls) e = nth bot ls (encode e).
 Proof.
   rewrite /of_seq build_lab /= /sub_lift.
   case: insubP=> /= [?? ->|] //.
   rewrite !in_fset /mem_fin /=.
-  rewrite in_nfresh encode1.
-  rewrite negb_and ltnNge negbK addn1 -ltnNge leqn0 ltnS.
-  case/orP=>[/eqP-> //|].
-  by move=> ?; rewrite nth_default.
+  rewrite in_nfresh encode0 addn0 /=.
+  rewrite ltnNge negbK=> ?. 
+  by rewrite nth_default.
 Qed.
 
 Lemma of_seq_fin_caE : 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -1888,6 +1888,7 @@ Proof.
   by move=> /negP + /eqP.
 Qed.
 
+(* TODO: fs_lab p e = nth bot (lfsp_labels p) (encode p e) ?? *)
 Lemma fs_lab_nthE p e :  
   fs_lab p e = nth bot (lfsp_labels p) (lfsp_idx p e).
 Proof. 
@@ -2883,9 +2884,7 @@ Proof.
     move=> e1In e2In Hca; apply/orP; right.
     rewrite !conseq_num_mem // /f !decodeK usz !lfsp_idx_lt_szE.
     apply/and3P; split=> //. 
-    (* TODO: make a lemma *)
-    rewrite /Order.le /= /Ident.Def.ident_le. 
-    rewrite !decodeK; exact/lfsp_idx_le.
+    rewrite ident_leE !decodeK; exact/lfsp_idx_le.
   - pose g : [Event of u] -> [Event of t] := 
       fun e => lfsp_event t \i0 (encode e).
     exists g=> e; rewrite !conseq_num_mem // /f /g !usz ?decodeK.
@@ -2894,8 +2893,7 @@ Proof.
   move=> e1 e2 e1In e2In; rewrite /f fs_caE /=.
   rewrite lFsPoset.of_seq_caE labD andbT //.
   rewrite !conseq_num_mem // !decodeK !usz !lfsp_idx_lt_szE.
-  rewrite /Order.le /= /Ident.Def.ident_le. 
-  rewrite !decodeK=> /orP[/eqP|].
+  rewrite ident_leE !decodeK=> /orP[/eqP|].
   - move=> /decode_inj /lfsp_idx_inj -> //; exact/fs_ca_refl.
   move=> /and3P[le12 ??].  
   move: (tomset_total_in e1In e2In).  
@@ -2905,79 +2903,6 @@ Proof.
   apply/(lfsp_idx_inj e1In e2In).
   by apply/le_anti/andP. 
 Qed.
-
-Lemma tomset_ihomE lt lu : 
-  let t := @of_seq E L bot lt in
-  let u := @of_seq E L bot lu in
-  ihom_le t u = subseq lu lt.
-Proof. 
-  rewrite /of_seq /Pomset.of_seq piE /=.
-  pose t := lFsPoset.of_seq E L bot lt. 
-  pose u := lFsPoset.of_seq E L bot lu. 
-  apply/idP/idP; first last.
-  - admit.
-  rewrite /of_seq /=.
-  move=> /ihom_leP [f] finj; apply/subseqP.
-  pose n := size lu.
-  pose m := size lt.
-  pose g : nat -> nat := fun i => encode (f (decode i)).
-  pose s := mkseq g n.
-  exists (mkmask s m)=> //.
-  - admit. (* rewrite size_mkmask ?size_nseq // all_map /=. *)
-  rewrite (@mask_mkmask _ bot)=> //.
-  - admit.
-  - rewrite /g=> /= i j. 
-    rewrite !mem_iota !add0n /=. 
-    move=> Hi Hj Hij.
-    apply/(@operational_sca E L bot t).
-    + exact/(lfsp_supp_closed t).
-    + exact/(lfsp_acyclic t).
-    + exact/lFsPoset.of_seq_operational.
-    rewrite -fs_scaE.
-    apply/sca_monotone_in=> /=. 
-    + exact/finj.
-    + admit.
-    + admit.
-      admit.
-  - move=> /= i j; rewrite !mem_iota !add0n /g /= => Hi Hj.
-    move=> /encode_inj/finj=> dinj.
-    apply/decode_inj/dinj.
-    + admit.
-    admit.
-  - admit.
-  admit.
-Admitted.
-
-
-(* TODO: use notation for ihom_le *)
-Lemma tomset_ihomE t u : 
-  ihom_le t u = subseq (lfsp_labels u) (lfsp_labels t).
-Proof. 
-  apply/idP/idP.
-  - move=> /ihom_leP [f] finj; apply/subseqP.
-    pose n := fs_size u.
-    pose m := fs_size t.
-    pose g : nat -> nat := fun i => 
-      (* TODO: set default for lfsp_event to fresh_seq? *)
-      let e := lfsp_event u (fresh_seq (finsupp u)) i in 
-      lfsp_idx t (f e).
-    pose s := mkseq g n.
-    exists (mkmask s m).
-    + rewrite size_mkmask ?size_nseq ?size_tuple // all_map /=.
-      subst g=> /=; apply/allP=> i /=.
-      rewrite mem_iota addnC addn0=> /andP[??]. 
-      by rewrite sub_liftT.
-    apply/esym; subst s. 
-    rewrite (@mkmask_mask L _ _ t)=> //.
-    + by move=> ???; apply (sca_monotone f).
-    + exact/ihom_inj.
-    by move=> ?; rewrite -tlabE -tlabE lab_preserving.
-  
-
-
-(* Lemma tomset_labelsK : 
-  cancel (@lfsp_labels E L bot) (@lFsPrePoset.of_seq E L bot).
-Proof. admit. Admitted. *)
 
 End Theory.
 End Theory.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -1236,7 +1236,7 @@ Section Def.
 Context (E : identType) (L : eqType).
 Variable (bot : L).
 
-Structure lfsposet : Type := lFsPoset {
+Structure lfsposet : Type := mklFsPoset {
   lfsposet_val :> lfspreposet E L bot ; 
   _ : let p := lfsposet_val in 
       [&& lab_defined p, supp_closed p & acyclic (fin_ica p)]
@@ -1360,7 +1360,7 @@ Qed.
 
 Definition of_seq ls : lfsposet E L bot := 
   if bot \notin ls =P true is ReflectT nbl then
-    lFsPoset (of_seqP nbl)
+    mklFsPoset (of_seqP nbl)
   else empty E L bot.
 
 Lemma of_seq_valE ls : 
@@ -1569,7 +1569,7 @@ Proof.
   exact/lFsPrePoset.restrict_acyclic. 
 Qed.
 
-Definition restrict P p := lFsPoset (restrictP P p).
+Definition restrict P p := mklFsPoset (restrictP P p).
 
 End Restrict.
 
@@ -1595,7 +1595,7 @@ Proof.
   exact/lFsPrePoset.relabel_acyclic. 
 Qed.
 
-Definition relabel := lFsPoset relabelP.
+Definition relabel := mklFsPoset relabelP.
 
 End Relabel.
 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -2717,6 +2717,28 @@ End Def.
 
 Arguments tomset E L bot : clear implicits.
 
+Section OfSeq.
+Context (E : identType) (L : choiceType) (bot : L). 
+Implicit Types (p : lfspreposet E L bot).
+Implicit Types (ls : seq L).
+
+Lemma of_seq_total ls : 
+  let p := @Pomset.of_seq E L bot ls in
+  total (fin_ca p).   
+Proof. 
+  pose p := @lFsPoset.of_seq E L bot ls.
+  rewrite /Pomset.of_seq=> /= e1 e2.
+  move: (iso_eqv_pom p)=> /lFinPoset.fisoP [f]. 
+  move: (lFsPoset.of_seq_total (f e1) (f e2)).
+  repeat rewrite -fin_caE.
+  by rewrite !(ca_reflecting f).
+Qed.
+
+Definition of_seq ls := 
+  mkTomset (introT (totalP _) (@of_seq_total ls)).
+
+End OfSeq.
+
 Module Export Theory.
 Section Theory.
 Context {E : identType} {L : choiceType}.

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -266,12 +266,11 @@ Qed.
 
 Lemma add_event_freshE :
   lfsp_fresh (lfspre_add_event l es p) = fresh (lfsp_fresh p).
-Proof. admit. Admitted.
-(*   rewrite finsupp_with xpair_eqE. *)
-(*   case: ifP=> [/andP[/eqP]|] //. *)
-(*   by move: lD=> /eqP. *)
-(* Qed. *)
-
+Proof. 
+  rewrite /lfsp_fresh add_event_finsuppE fresh_seq_add.
+  rewrite /lfsp_fresh max_l //.
+  exact/ltW/fresh_lt.
+Qed. 
 
 End Theory.
 End Theory.  

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -508,10 +508,10 @@ Proof.
   - exists id; split=> //; last by exists id.
   repeat constructor.
   - move=> e; rewrite !fs_labE.
-    rewrite lFsPoset.of_seq_valE ?lFsPrePoset.of_seq_labE //=.
+    rewrite lFsPoset.of_seq_valE labsD ?lFsPrePoset.of_seq_labE //=.
     by rewrite lfsp_trace_lab.
   move=> e1 e2; rewrite !fs_caE.
-  rewrite lFsPoset.of_seq_valE ?lFsPrePoset.of_seq_fs_caE //.
+  rewrite lFsPoset.of_seq_valE labsD ?lFsPrePoset.of_seq_fs_caE //.
   rewrite !lFsPrePoset.of_seq_finsupp //=.
   rewrite !in_fset /= !size_labels. 
   move: (lfsp_supp_closed p)=> supcl.

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -429,6 +429,8 @@ Proof.
   by case/andP=> /fresh_seq_mem/ltW ??? /eqP->.
 Qed.
 
+(* TODO: invariant_conseq_num ? *)
+
 Lemma lfsp_trace_fresh tr p:
   let emp := lFsPoset.empty E L bot in
   p = lst_state emp tr ->

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -545,12 +545,11 @@ Proof.
   move=> /=; rewrite /trace_lang ?/(_ \in _) /= /lin /=.
   move/bhom_le_size; rewrite lFsPoset.of_seq_size size_map.
   rewrite lfsp_trace_labels_defined.  
-  move=> sizeE; apply/eqP/esym/val_inj/lFsPrePoset.eq_emptyE=> /=.
+  move=> sizeE; apply/eqP/esym/val_inj/lFsPrePoset.empty_eqP=> /=. 
   set f := [eta (@fs_size E L bot)]: lfsposet _ _ _ -> nat.
   move: (@measure_lst _ _ _ f S) sizeE=> /=; rewrite /f /= /==> -> //.
   - rewrite iter_succn; lia.
-  move=> s s' l.
-  case/lfsp_ltransP=> ? [?? ->]. 
+  move=> s s' l; case/lfsp_ltransP=> ? [?? ->]. 
   by rewrite lfsp_add_eventE.
 Qed.
 

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -299,7 +299,7 @@ Definition lfsp_add_event l es p : lfsposet E L bot :=
                    (lfsp_supp_closed p) 
                    (lfsp_acyclic p) 
     in
-     (introT and3P (And3 labD supcl acyc)))
+    (introT and3P (And3 labD supcl acyc)))
   end.
 
 End Def.
@@ -360,22 +360,6 @@ Implicit Types (tr : trace (LTS.ltsType E L bot)).
 Import lPoset.Syntax.
 Local Open Scope lts_scope.
 
-Lemma lfsp_ltransP l p q :
-  reflect (l != bot /\ exists2 es, 
-             es `<=` finsupp p & 
-             q = lfsp_add_event l es p)
-          (p --[l]--> q).
-Proof.
-  rewrite /ltrans /= /LTS.ltrans.
-  apply: (andPP idP). 
-  apply/(equivP idP); split=> [/existsP|] /=.
-  - move=> [es] /eqP->; exists (val es)=> //.
-    rewrite -fpowersetE; exact/(valP es). 
-  move=> [es] + ->; rewrite -fpowersetE.
-  move=> inPw; apply/existsP=> /=.
-  by exists (Sub es inPw).
-Qed.
-
 Lemma lfsp_add_eventE l es p : l != bot -> (es `<=` finsupp p) ->
   (* --- *)
   ((finsupp (lfsp_add_event l es p) =  lfsp_fresh p |` finsupp p)               *
@@ -407,9 +391,24 @@ Proof.
     //; case: (p)=> /=> /and3P[] //.
 Qed.
 
-Notation of_seq := (lFsPoset.of_seq E L bot).
-
+(* TODO: remove hints? *)
 Hint Resolve lfsp_supp_closed lfsp_acyclic : core.
+
+Lemma lfsp_ltransP l p q :
+  reflect (l != bot /\ exists2 es, 
+             es `<=` finsupp p & 
+             q = lfsp_add_event l es p)
+          (p --[l]--> q).
+Proof.
+  rewrite /ltrans /= /LTS.ltrans.
+  apply: (andPP idP). 
+  apply/(equivP idP); split=> [/existsP|] /=.
+  - move=> [es] /eqP->; exists (val es)=> //.
+    rewrite -fpowersetE; exact/(valP es). 
+  move=> [es] + ->; rewrite -fpowersetE.
+  move=> inPw; apply/existsP=> /=.
+  by exists (Sub es inPw).
+Qed.
 
 Lemma lfsp_trace_labels_defined tr : 
   bot \notin labels tr.
@@ -428,13 +427,6 @@ Proof.
   case/andP=> /lfsp_dw_closP[] // ? /supp_closed_ca/orP[]//.
   - by move/eqP=>-> /sub/fresh_seq_mem/ltW ? /eqP->.
   by case/andP=> /fresh_seq_mem/ltW ??? /eqP->.
-Qed.
-
-Lemma opetaional0 : operational (lFsPoset.empty E L bot).
-Proof.
-  rewrite /lFsPoset.empty /=.
-  apply/forall2P=> ??; rewrite lFsPrePoset.fs_ca_empty.
-  by apply/implyP=> /eqP->.
 Qed.
 
 Lemma lfsp_trace_fresh tr p:
@@ -541,7 +533,8 @@ Proof.
   rewrite lfsp_trace_finsupp // !inE => ???.
   apply/orP; right; apply/and3P; split=> //.
   apply/(fs_ca_ident_le supcl acyc)=> //.
-  exact/(invariant_trace_lan invariant_operational)/opetaional0.
+  apply/(invariant_trace_lang invariant_operational)=> //. 
+  exact/lFsPrePoset.empty_operational.
 Qed.
 
 Lemma lfsp_lin_trace_lang tr : 

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -328,7 +328,7 @@ Context {L : choiceType} {bot : L}.
 
 Definition lfsposet_of (E : eventType L) (X : {fset E}) : lfsposet E L bot :=
   if eqP is ReflectT p then
-    lFsPoset (@lfspreposet_of_mixin L bot E X p)
+    mklFsPoset (@lfspreposet_of_mixin L bot E X p)
   else (lFsPoset.empty E L bot).
 
 Context (E : eventType L) (X : {fset E}).

--- a/theories/concur/transitionsystem.v
+++ b/theories/concur/transitionsystem.v
@@ -147,7 +147,10 @@ Qed.
 
 Lemma add_fed0 : 
   add_fed ident0 = {| lab_prj := \init; fpo_prj := ident0; frf_prj := ident0 |}.
-Proof. rewrite add_fedE lt_eqF=> //; [ exact/fed0 | exact/fresh_seq0 ]. Qed.
+Proof. 
+  rewrite add_fedE lt_eqF; first exact/fed0.
+  exact/fresh_seq_mem/dom0.  
+Qed.
 
 Fact add_fpo_dom :
   [forall e : finsupp add_fed, add_fpo (val e) \in fresh_id :: dom].


### PR DESCRIPTION
The main contribution of this PR is lemma `tomset_labelsK`, which is a part of the proof that tomsets are isomorphic to sequences. 

Additional features introduced in this PR:
*  `conseq_num`  property of posets, asserting that events of the poset form a consecutive sequence of events, from `0` to `n`
* changed definition of `fresh_seq` to simplify proof of `tomset_labelsK`, as a by-product simplify proofs in `pomset_lts.v` to remove unnecessary case-analysis. 
