### PR TITLE
Refactor Pomset's events and labels representation

### DIFF
--- a/theories/common/ident.v
+++ b/theories/common/ident.v
@@ -1,6 +1,6 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq path.
 From mathcomp Require Import finmap choice eqtype order zify.
-From eventstruct Require Import utils order wftype.
+From eventstruct Require Import utils inhtype order wftype.
 
 (******************************************************************************)
 (* This file contains a theory of types that can be used as identifiers.      *)
@@ -226,10 +226,29 @@ Proof. exact/pickle_inj. Qed.
 End Props.
 End Props.
 
+Module Export Inh. 
+Section Inh. 
+Context (T : identType).
+Implicit Types (x y z : T).
+
+Lemma disp : unit. 
+Proof. exact: tt. Qed.
+
+Definition inhMixin := @Inhabited.Mixin T _ ident0.
+Definition inhType := Eval hnf in InhType T disp inhMixin.
+
+End Inh.
+
+Module Export Exports.
+Canonical inhType.
+Coercion inhType : type >-> Inhabited.type.
+End Exports.
+
+End Inh.
+
 
 Module Export Order. 
 Section Order. 
-
 Context (T : identType).
 Implicit Types (x y z : T).
 
@@ -465,7 +484,7 @@ Proof. by rewrite /nfresh; exact/trajectSr. Qed.
 Lemma in_nfresh x n y : 
   y \in nfresh x n = (encode x <= encode y < n + encode x)%N.
 Proof.
-  elim: n x=> //= [?|?/[swap] ?]; rewrite ?(inE, in_nil); first lia.
+  elim: n x=> //= [? |?/[swap] ?]; rewrite ?(inE, in_nil); first lia.
   move=>->; rewrite encode_fresh -(inj_eq encode_inj); lia.
 Qed.
 
@@ -519,7 +538,7 @@ Lemma fresh_seq_subset s1 s2 :
   {subset s1 <= s2} -> fresh_seq s1 <=^i fresh_seq s2.
 Proof.
   rewrite /fresh_seq. 
-  elim: s1 s2=> [??|] //=; first exact/le0x. 
+  elim: s1 s2=> [?? |] //=; first exact/le0x. 
   move=> a s1 IH s2 subs.
   rewrite le_maxl; apply/andP; split.
   - apply/max_seq_in_le; rewrite (mem_map fresh_inj). 
@@ -561,6 +580,7 @@ End Theory.
 End Ident.
 
 Export Ident.Exports.
+Export Ident.Inh.Exports.
 Export Ident.Order.Exports.
 Export Ident.Def.
 Export Ident.Props.

--- a/theories/common/inhtype.v
+++ b/theories/common/inhtype.v
@@ -124,5 +124,20 @@ End Inhabited.
 
 Export Inhabited.Exports.
 
+
+Module Bottom. 
+
+Lemma disp : unit.
+Proof. exact: tt. Qed.
+
+Module Exports.
+Notation botType := (@Inhabited.type disp).
+Notation BotType T m := (@Inhabited.pack T disp _ _ id m).
+Definition bot {T : botType} : T := @inh _ T. 
+End Exports.
+End Bottom. 
+
+Export Bottom.Exports.
+
 Definition nat_inhMixin := @Inhabited.Mixin nat _ 0.
 Canonical nat_inhType := Eval hnf in InhType nat tt nat_inhMixin.

--- a/theories/common/inhtype.v
+++ b/theories/common/inhtype.v
@@ -2,6 +2,27 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq fintype order.
 From mathcomp Require Import eqtype choice fingraph path. 
 From eventstruct Require Import utils.
 
+(******************************************************************************)
+(* This file provides a theory of inhabited types, i.e. types with one        *)
+(* distinguished inhabitant.                                                  *)
+(*            ?|T| == propositional assertion that type T has an inhabitant.  *)
+(*           ??|T| == boolean assertion that finite type T has an inhabitant. *)
+(*       inhType d == inhabited type.                                         *)
+(*         inh : T == distinguished inhabitant of the type T.                 *)
+(*         botType == special kind of inhabited types where the               *)
+(*                    distinguished inhabitant represets bottom               *)
+(*                    (i.e. undefined value).                                 *)
+(*         bot : T == bottom of the type T.                                   *)
+(*   {homo bot f} <-> f is a homomorphism between types with bottom:          *)
+(*                    f bot = bot.                                            *)
+(*                                                                            *)
+(* We also provide canonical instance of inhType for the following types:     *)
+(* - nat with inhabitant 0;                                                   *)
+(* - product type T * U with inhabitant (inh : T, inh : U);                   *)
+(*                                                                            *)
+(******************************************************************************)
+
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/common/inhtype.v
+++ b/theories/common/inhtype.v
@@ -181,3 +181,9 @@ Export Bottom.Syntax.
 
 Definition nat_inhMixin := @Inhabited.Mixin nat _ 0.
 Canonical nat_inhType := Eval hnf in InhType nat tt nat_inhMixin.
+
+Definition prod_inhMixin {dT dU} (T : inhType dT) (U : inhType dU) := 
+  @Inhabited.Mixin _ _ (inh : T, inh : U).
+Canonical prod_inhType {dT dU dTU} (T : inhType dT) (U : inhType dU) := 
+  Eval hnf in InhType (T * U) dTU (prod_inhMixin T U). 
+

--- a/theories/common/inhtype.v
+++ b/theories/common/inhtype.v
@@ -104,7 +104,7 @@ Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
 End ClassDef.
 
-Module Exports.
+Module Export Exports.
 Coercion base : class_of >-> Choice.class_of.
 Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
@@ -117,12 +117,36 @@ Notation "[ 'inhType' 'of' T 'for' cT ]" := (@clone T _ cT _ id)
   (at level 0, format "[ 'inhType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'inhType' 'of' T ]" := [inhType of T for _]
   (at level 0, format "[ 'inhType'  'of'  T ]") : form_scope.
-Definition inh {disp} {T : inhType disp} : T := inh (mixin (class T)).
 End Exports.
+
+Module Export Def.
+Section Def.
+Context {disp : unit} {T : inhType disp}.
+
+Definition inh : T := (inh (mixin (class T))).
+
+End Def.
+
+Section Homo.
+Context {dispT dispU : unit} {T : inhType dispT} {U : inhType dispU}.
+Implicit Types (f : T -> U).
+
+Definition homo_inh f : bool := 
+  (f inh == inh).
+
+End Homo.
+End Def.
+
+Module Export Syntax.
+Notation "{ 'homo' 'inh' f }" := (homo_inh f)
+  (at level 0, f at level 99, format "{ 'homo'  'inh'  f }") : type_scope.
+End Syntax.
 
 End Inhabited.
 
 Export Inhabited.Exports.
+Export Inhabited.Def.
+Export Inhabited.Syntax.
 
 
 Module Bottom. 
@@ -130,14 +154,30 @@ Module Bottom.
 Lemma disp : unit.
 Proof. exact: tt. Qed.
 
-Module Exports.
+Module Export Exports.
 Notation botType := (@Inhabited.type disp).
 Notation BotType T m := (@Inhabited.pack T disp _ _ id m).
-Definition bot {T : botType} : T := @inh _ T. 
 End Exports.
+
+Module Export Def.
+Section Def.
+Context {T : botType}.
+Definition bot : T := @inh _ T. 
+End Def.
+End Def.
+
+Module Export Syntax.
+(* TODO: enforce that f is a function from/to botType ? *)
+Notation "{ 'homo' 'bot' f }" := (homo_inh f)
+  (at level 0, f at level 99, format "{ 'homo'  'bot'  f }") : type_scope.
+End Syntax.
+
 End Bottom. 
 
 Export Bottom.Exports.
+Export Bottom.Def.
+Export Bottom.Syntax.
+
 
 Definition nat_inhMixin := @Inhabited.Mixin nat _ 0.
 Canonical nat_inhType := Eval hnf in InhType nat tt nat_inhMixin.

--- a/theories/common/inhtype.v
+++ b/theories/common/inhtype.v
@@ -71,7 +71,6 @@ End Theory.
 
 
 Module Inhabited.
-
 Section ClassDef.
 
 Record mixin_of T0 (b : Choice.class_of T0) 
@@ -88,18 +87,18 @@ Unset Primitive Projections.
 
 Local Coercion base : class_of >-> Choice.class_of.
 
-Structure type := Pack { sort; _ : class_of sort }.
+Structure type (disp : unit) := Pack { sort; _ : class_of sort }.
 
 Local Coercion sort : type >-> Sortclass.
 
-Variables (T : Type) (cT : type).
+Variables (T : Type) (disp : unit) (cT : type disp).
 
 Definition class := let: Pack _ c as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c.
+Definition clone c of phant_id class c := @Pack disp T c.
 
 Definition pack :=
   fun bT b & phant_id (Choice.class bT) b =>
-  fun m => Pack (@Class T b m).
+  fun m => Pack disp (@Class T b m).
 
 Definition eqType := @Equality.Pack cT class.
 Definition choiceType := @Choice.Pack cT class.
@@ -113,12 +112,12 @@ Coercion choiceType : type >-> Choice.type.
 Canonical eqType.
 Canonical choiceType.
 Notation inhType := type.
-Definition inh {T : inhType} : T := inh (mixin (class T)).
-Notation Inhabited T m := (@pack T _ _ id m).
-Notation "[ 'inhType' 'of' T 'for' cT ]" := (@clone T cT _ id)
+Notation InhType T d m := (@pack T d _ _ id m).
+Notation "[ 'inhType' 'of' T 'for' cT ]" := (@clone T _ cT _ id)
   (at level 0, format "[ 'inhType'  'of'  T  'for'  cT ]") : form_scope.
 Notation "[ 'inhType' 'of' T ]" := [inhType of T for _]
   (at level 0, format "[ 'inhType'  'of'  T ]") : form_scope.
+Definition inh {disp} {T : inhType disp} : T := inh (mixin (class T)).
 End Exports.
 
 End Inhabited.
@@ -126,4 +125,4 @@ End Inhabited.
 Export Inhabited.Exports.
 
 Definition nat_inhMixin := @Inhabited.Mixin nat _ 0.
-Canonical nat_inhType := Eval hnf in Inhabited nat nat_inhMixin.
+Canonical nat_inhType := Eval hnf in InhType nat tt nat_inhMixin.

--- a/theories/common/rel.v
+++ b/theories/common/rel.v
@@ -67,6 +67,14 @@ Proof.
   by firstorder.
 Qed.
 
+Lemma sub_irrefl r1 r2 :
+  subrel r1 r2 -> irreflexive r2 -> irreflexive r1.
+Proof. by move=> sub irr x; apply/idP=> /sub; rewrite irr. Qed.
+
+Lemma sub_antisym r1 r2 :
+  subrel r1 r2 -> antisymmetric r2 -> antisymmetric r1.
+Proof. move=> sub anti x y /andP[??]; apply/anti/andP; split; exact/sub. Qed.
+
 Lemma eq_irrefl r1 r2 : 
   r1 =2 r2 -> irreflexive r1 <-> irreflexive r2.
 Proof. 
@@ -309,6 +317,14 @@ Definition iker r : rel T :=
   fun x y => (y != x) && r x y.
 
 Lemma iker_qmk r : 
+  iker (r : {dhrel T & T})^? =2 iker r.
+Proof. 
+  move=> x y; rewrite /iker dhrel_qmkE /=.
+  rewrite andb_orr orb_idl //. 
+  by rewrite eq_sym=> /andP[] /negP.
+Qed.
+
+Lemma qmk_iker r : 
   reflexive r -> (iker r : {dhrel T & T})^? =2 r.
 Proof. 
   move=> refl x y ; rewrite dhrel_qmkE /= /iker.

--- a/theories/common/rel.v
+++ b/theories/common/rel.v
@@ -83,7 +83,67 @@ Proof.
   rewrite !eqr; exact/anti.
 Qed.
 
-End Rel. 
+Lemma eq_trans r1 r2 : 
+  r1 =2 r2 -> transitive r1 <-> transitive r2.
+Proof. 
+  move=> eqr; split=> trans z x y.
+  - rewrite -?eqr; exact/trans.
+  rewrite ?eqr; exact/trans.
+Qed.
+
+End Rel.
+
+Section ClosRefl.
+Context {T : eqType}.
+Implicit Types (r : {dhrel T & T}). 
+
+Lemma dhrel_qmkE r :
+  r^? =2 [rel x y | (x == y) || (r x y)].
+Proof. done. Qed.
+
+Lemma qmk_refl r :
+  reflexive r^?.
+Proof. by move=> x; rewrite dhrel_qmkE /= eqxx. Qed.
+
+Lemma qmk_antisym r :
+  antisymmetric r -> antisymmetric r^?.
+Proof. 
+  move=> asym x y; rewrite !dhrel_qmkE /=.
+  move=> /andP[] /orP[/eqP->|?] // /orP[/eqP->|?] //.
+  by apply/asym/andP.  
+Qed.
+  
+Lemma qmk_trans r :
+  transitive r -> transitive r^?.
+Proof.
+  move=> trans z x y; rewrite !dhrel_qmkE /=.
+  move=> /orP[/eqP<-|rxz] // /orP[/eqP<-|rzy] //.
+  apply/orP; right; apply/trans; [exact/rxz|exact/rzy]. 
+Qed.
+
+End ClosRefl.
+
+Section SubRelLift.
+Context {T : eqType} {U : Type} {P : pred T} {S : subType P}.
+
+Lemma sub_rel_lift_qmk (r : {dhrel S & S}) :
+  (sub_rel_lift r : {dhrel T & T})^? =2 (sub_rel_lift r^? : {dhrel T & T})^?. 
+Proof. 
+  move=> x y; rewrite !dhrel_qmkE /=.
+  apply/idP/idP=> [/orP[|]|].
+  - by move=> /eqP->; rewrite eqxx. 
+  - move=> /sub_rel_liftP[] x' [] y' [] ? <- <-.
+    apply/orP; right; apply/sub_rel_liftP. 
+    exists x', y'; split=> //=.
+    by apply/orP; right. 
+  move=> /orP[/eqP->|]; rewrite ?eqxx //.
+  move=> /sub_rel_liftP[] x' [] y' [] /= + <- <-.
+  move=> /orP[/eqP->|]; rewrite ?eqxx //.
+  move=> ?; apply/orP; right; apply/sub_rel_liftP.
+  by exists x', y'.
+Qed.
+
+End SubRelLift.
 
 Section FinGraph. 
 Context {T : finType}.

--- a/theories/common/relalg.v
+++ b/theories/common/relalg.v
@@ -56,6 +56,10 @@ Lemma qmk_weq `{laws} `{CUP ≪ l} n (x y : X n n):
   x ≡ y -> x^? ≡ y^?.
 Proof. by move => ->. Qed.
 
+Lemma qmk_str `{laws} `{BKA ≪ l} n (x : X n n) :
+  x^*^? ≡ x^*.
+Proof. ka. Qed.
+
 (* ************************************************************************** *)
 (*     Subtraction (for complemented lattices, i.e. lattices with negation)   *)
 (* ************************************************************************** *)
@@ -474,6 +478,10 @@ End RelClos.
 Section FinRel.
 Context {T : finType}.
 Implicit Types (R : hrel T T) (r : rel T).
+
+Lemma connect_strE r : 
+  (r : {fhrel T & T})^* ≡ (connect r).
+Proof. done. Qed.
 
 Lemma connect_strP r x y : 
   reflect ((r : hrel T T)^* x y) (connect r x y).

--- a/theories/common/relalg.v
+++ b/theories/common/relalg.v
@@ -2,7 +2,8 @@ From Coq Require Import Relations.
 From mathcomp Require Import ssreflect ssrbool ssrnat ssrfun eqtype.
 From mathcomp Require Import seq path fingraph fintype.
 From mathcomp.tarjan Require Import extra acyclic kosaraju acyclic_tsorted. 
-From RelationAlgebra Require Import lattice monoid boolean rel fhrel kat_tac.
+From RelationAlgebra Require Import lattice monoid boolean rel fhrel. 
+From RelationAlgebra Require Import kleene kat_tac.
 
 (* ************************************************************************** *)
 (*   Missing definitions, notations and lemmas for relation-algebra package   *)
@@ -30,14 +31,13 @@ End PropUtils.
 (*     Cartesian product for lattice-valued functions                         *)
 (* ************************************************************************** *)
 
-Section CartesianProd.
-
+Section Prod.
 Context {T : Type} {L : lattice.ops}.
 
 Definition cart_prod (p q : T -> L) : T -> T -> L :=
   fun x y => p x ⊓ q y.
 
-End CartesianProd.
+End Prod.
 
 Notation "p × q" := (cart_prod p q) (at level 60, no associativity) : ra_terms.
 
@@ -452,6 +452,17 @@ Proof.
   rewrite str_itr clos_rt_crE clos_r_qmk.
   by rewrite clos_t_itr. 
 Qed.
+
+Lemma itr_prod (D : T -> Prop) : 
+  (D × D : hrel T T)^+ ≡ D × D.
+Proof. 
+  apply/weq_spec; split; last exact/itr_ext. 
+  by apply/itr_ind_l1=> //= x y [] z [] ++ []. 
+Qed.
+
+Lemma clos_t_restr R D :
+  R ≦ D × D -> R^+ ≦ D × D.
+Proof. move=> rD; rewrite -itr_prod; exact/itr_leq. Qed.
 
 (* TODO: this cannot be proven for KA+NEG, 
  *   because hrel does not have NEG

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -67,6 +67,10 @@ Proof.
   apply: eqP; apply/iff_eqP; intuition.
 Qed.
 
+Lemma nmem_subset {T : Type} (p q : pred T) x : 
+  {subset p <= q} -> x \notin q -> x \notin p.
+Proof. by move=> subs; apply/contra=> ?; rewrite subs. Qed.
+
 (* ************************************************************************** *)
 (*     Anti-homomorphism (i.e. homomorphism with reversed direction)          *)
 (* ************************************************************************** *)

--- a/theories/common/utils.v
+++ b/theories/common/utils.v
@@ -929,6 +929,16 @@ Proof.
   by rewrite /rl /sub_rel_lift /= !insubT !andbT !sub_val.
 Qed.
 
+Lemma sub_rel_lift_antisym r : 
+  antisymmetric r -> antisymmetric (sub_rel_lift r).
+Proof. 
+  move=> asym x y. 
+  rewrite /sub_rel_lift /=. 
+  case: insubP=> // x' ? <-.
+  case: insubP=> // y' ? <-.
+  by move=> /asym ->.
+Qed.
+
 Lemma sub_rel_lift_trans r : 
   transitive r -> transitive (sub_rel_lift r).
 Proof. 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -937,13 +937,11 @@ Qed.
 
 (* TODO: /end/ the following proofs should be simpler :( *)
 
-Lemma empty_eqP p : supp_closed p -> 
-  reflect (p = empty) (lfsp_size p == 0%N).
+Lemma size0_empty p : 
+  supp_closed p -> lfsp_size p = 0%N -> p = empty.
 Proof.
   move=> supcl.
-  apply/(equivP idP); split=> [|->]; last first. 
-  - by rewrite fs_size_empty. 
-  rewrite /lfsp_size=> /eqP/cardfs0_eq fE. 
+  rewrite /lfsp_size=> /cardfs0_eq fE. 
   apply/eqP/lfspreposet_eqP; split=> >.
   - rewrite fs_lab_empty fs_lab_bot ?fE //.
   rewrite fs_ica_empty /fs_ica /=. 
@@ -1526,7 +1524,7 @@ Lemma of_seq_size ls :
 Proof. 
   rewrite of_seq_valE; case: ifP=> ?. 
   - by rewrite lFsPrePoset.of_seq_size. 
-  exact/eqP/lFsPrePoset.empty_eqP.
+  by rewrite lFsPrePoset.fs_size_empty. 
 Qed.
 
 Lemma of_seq_labE ls e :

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -120,25 +120,25 @@ Definition fs_ca p : rel E :=
 Definition fs_sca p : rel E := 
   fun e1 e2 => (e2 != e1) && (fs_ca p e1 e2).
 
-Definition lfsp_events p : {fset E} := 
+Definition lfsp_eventset p : {fset E} := 
   [fset e in finsupp p | fs_lab p e != bot].
 
 (* TODO: rename lfsp_size? *)
-Definition fs_size p : nat := #|` lfsp_events p|.
+Definition fs_size p : nat := #|` lfsp_eventset p|.
 
 Definition supp_closed p := 
   [forall e : finsupp p, forall e' : fs_rcov p (val e), 
-    (val e \in lfsp_events p) && (val e' \in lfsp_events p) 
+    (val e \in lfsp_eventset p) && (val e' \in lfsp_eventset p) 
   ].
 
 (* TODO: better name? *)
 Definition operational p := 
-  [forall e1 : lfsp_events p, forall e2 : lfsp_events p, 
+  [forall e1 : lfsp_eventset p, forall e2 : lfsp_eventset p, 
     (fs_ca p (val e1) (val e2)) ==> (val e1 <=^i val e2)
   ].
 
 Definition conseq_num p :=
-  lfsp_events p == [fset e | e in nfresh \i0 (fs_size p)].
+  lfsp_eventset p == [fset e | e in nfresh \i0 (fs_size p)].
 
 Definition lfsp_tseq p : seq E := 
   map val (tseq (rgraph (@fin_ica p))).
@@ -153,26 +153,26 @@ Definition lfsp_labels p : seq L :=
   map (fs_lab p) (lfsp_tseq p).
 
 Definition lfsp_fresh p : E := 
-  fresh_seq (lfsp_events p).
+  fresh_seq (lfsp_eventset p).
 
 Definition lfsp_pideal p e : {fset E} := 
-  [fset e' in (e |` lfsp_events p) | fs_ca p e' e].
+  [fset e' in (e |` lfsp_eventset p) | fs_ca p e' e].
 
 (* TODO: unify with UpFinPOrder *)
 Definition lfsp_dw_clos p es := 
-  [seq e <- lfsp_events p | [exists e' : es, fs_ca p e (val e')]].
+  [seq e <- lfsp_eventset p | [exists e' : es, fs_ca p e (val e')]].
 
 (* TODO: unify with UpFinPOrder *)
 Definition lfsp_is_maximal p e := 
-  [forall e' : lfsp_events p, (fs_ca p e (val e')) ==> (fs_ca p (val e') e)].
+  [forall e' : lfsp_eventset p, (fs_ca p e (val e')) ==> (fs_ca p (val e') e)].
 
 (* TODO: unify with UpFinPOrder *)
 Definition lfsp_is_greatest p e := 
-  [forall e' : lfsp_events p, fs_ca p (val e') e].
+  [forall e' : lfsp_eventset p, fs_ca p (val e') e].
 
 Definition lfsp_equiv_partition p r : {fset {fset E}} := 
-  let part := equivalence_partition r [set: lfsp_events p] in
-  [fset [fset (val e) | e : lfsp_events p & (e \in (P : {set _}))] | P in part].
+  let part := equivalence_partition r [set: lfsp_eventset p] in
+  [fset [fset (val e) | e : lfsp_eventset p & (e \in (P : {set _}))] | P in part].
 
 (* TODO: move/restructure *)
 Context (L' : eqType) (bot' : L').
@@ -183,7 +183,7 @@ Definition bot_preserving f :=
   f bot == bot'.
 
 Definition finsupp_preserving p f := 
-  [forall e : lfsp_events p, f (fs_lab p (val e)) != bot'].
+  [forall e : lfsp_eventset p, f (fs_lab p (val e)) != bot'].
 
 End Def.
 
@@ -235,7 +235,7 @@ Qed.
 
 Lemma supp_closedP p : 
   reflect (forall e1 e2, fs_ica p e1 e2 -> 
-            (e1 \in lfsp_events p) * (e2 \in lfsp_events p))
+            (e1 \in lfsp_eventset p) * (e2 \in lfsp_eventset p))
           (supp_closed p).
 Proof. 
   rewrite /supp_closed /fs_ica.
@@ -250,10 +250,7 @@ Proof.
     by rewrite /fs_rcov=> /[swap] -> /= //.
   move: in1=> /[swap] -> in1.
   move: (all_supp e2' (Sub e1 in1))=> /=. 
-  case: (val e2' \in lfsp_events p)=> /=.
-  move=> /implyP.  
-  - move: (all_supp e2')=> /fsubsetP /[swap] /= <- /[apply] ->. *)
-  by move=> /fsfun_dflt -> //.
+  by move=> /andP[-> ->].
 Qed.
 
 Lemma fs_sca_def p e1 e2 : 

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -78,8 +78,7 @@ Module lFsPrePoset.
 
 Module Export Def.
 Section Def.
-(* TODO: perhaps, it is better to make L : inhType *)
-Context (E : identType) (L : eqType) (bot : L).
+Context (E : identType) (L : botType).
 
 (* TODO: perhaps, we should actually enforce 
  *   lab_defined and supp_closed properties here
@@ -174,37 +173,32 @@ Definition lfsp_equiv_partition p r : {fset {fset E}} :=
   [fset [fset (val e) | e : lfsp_eventset p & (e \in (P : {set _}))] | P in part].
 
 (* TODO: move/restructure *)
-Context (L' : eqType) (bot' : L').
+Context (L' : botType).
 Implicit Types (f : L -> L').
 
-(* TODO: move to inhtype, make a type of inhtype morphisms? *)
-Definition bot_preserving f := 
-  (f bot == bot').
-
 Definition finsupp_preserving p f := 
-  [forall e : lfsp_eventset p, f (fs_lab p (val e)) != bot'].
+  [forall e : lfsp_eventset p, f (fs_lab p (val e)) != bot].
 
 End Def.
 
-Arguments fs_lab {E L bot} p.
-Arguments fs_ica {E L bot} p.
-Arguments fs_sca {E L bot} p.
-Arguments fs_ca  {E L bot} p.
+Arguments fs_lab {E L} p.
+Arguments fs_ica {E L} p.
+Arguments fs_sca {E L} p.
+Arguments fs_ca  {E L} p.
 
-Arguments fin_lab {E L bot} p.
-Arguments fin_ica {E L bot} p.
-Arguments fin_sca {E L bot} p.
-Arguments fin_ca  {E L bot} p.
+Arguments fin_lab {E L} p.
+Arguments fin_ica {E L} p.
+Arguments fin_sca {E L} p.
+Arguments fin_ca  {E L} p.
 
 End Def.
 
-Arguments lfspreposet E L bot : clear implicits.
+Arguments lfspreposet E L : clear implicits.
 
 Module Export Theory.
 Section Theory.
-Context (E : identType) (L : eqType).
-Variable (bot : L).
-Implicit Types (p q : lfspreposet E L bot) (ls : seq L).
+Context (E : identType) (L : botType).
+Implicit Types (p q : lfspreposet E L) (ls : seq L).
 
 (* ************************************************************************** *)
 (*     Switching between finType <-> finsupp                                  *)
@@ -708,9 +702,9 @@ Qed.
 End Theory.
 
 Section TheoryAux.
-Context (E : identType) (L1 : eqType) (L2 : eqType) (bot1 : L1) (bot2 : L2).
-Implicit Types (p : lfspreposet E L1 bot1).
-Implicit Types (q : lfspreposet E L2 bot2).
+Context (E : identType) (L1 : botType) (L2 : botType).
+Implicit Types (p : lfspreposet E L1).
+Implicit Types (q : lfspreposet E L2).
 
 Lemma fs_ca_ica_eq p q : supp_closed p -> lfsp_eventset p = lfsp_eventset q -> 
   fs_ica p =2 fs_ica q -> fs_ca p =2 fs_ca q.
@@ -736,12 +730,12 @@ End TheoryAux.
 End Theory.
 
 Section Build.
-Context (E : identType) (L : eqType) (bot : L). 
+Context (E : identType) (L : botType).
 Context (fE : {fset E}).
-Implicit Types (p : lfspreposet E L bot).
+Implicit Types (p : lfspreposet E L).
 Implicit Types (lab : fE -> L) (ica : rel fE) (ca : rel E).
 
-Definition build lab ica : lfspreposet E L bot := 
+Definition build lab ica : lfspreposet E L := 
   let rcov e := [fsetval e' in rgraph [rel x y | ica y x] e] in
   [fsfun e => (lab e, rcov e)].
 
@@ -808,15 +802,15 @@ Qed.
 End Build.
 
 Section BuildCov.
-Context (E : identType) (L : eqType) (bot : L). 
+Context (E : identType) (L : botType).
 Context (fE : {fset E}).
-Implicit Types (p : lfspreposet E L bot).
+Implicit Types (p : lfspreposet E L).
 Implicit Types (lab : fE -> L) (ica : rel fE) (ca : rel E).
 
-Definition build_cov lab ca : lfspreposet E L bot := 
+Definition build_cov lab ca : lfspreposet E L := 
   let sca : rel E := (fun x y => (y != x) && (ca x y)) in
   let ica : rel fE := cov (relpre val sca) in
-  @build E L bot fE lab ica.
+  build lab ica.
 
 Variables  (lab : fE -> L) (ca : rel E).
 Hypothesis (labD : forall e, lab e != bot).
@@ -835,7 +829,7 @@ Proof.
   rewrite /fin_ica /sub_rel_down /=.
   rewrite build_ica /sub_rel_lift /=.
   do ? case: insubP=> [??? |/negP//].
-  move: in1 in2; case: _ / (esym (@build_eventset E L bot fE lab ica labD))=> *.
+  move: in1 in2; case: _ / (esym (@build_eventset E L fE lab ica labD))=> *.
   apply/congr2/val_inj=> //; exact/val_inj.
 Qed.
 
@@ -922,10 +916,10 @@ Qed.
 End BuildCov.
 
 Section Empty.
-Context (E : identType) (L : eqType) (bot : L). 
-Implicit Types (p : lfspreposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : lfspreposet E L).
 
-Definition empty : lfspreposet E L bot := [fsfun].
+Definition empty : lfspreposet E L := [fsfun].
 
 Lemma eventset_empty : 
   lfsp_eventset empty = fset0.
@@ -1024,18 +1018,18 @@ Qed.
 
 End Empty.
 
-Arguments empty E L bot : clear implicits.
+Arguments empty E L : clear implicits.
 
 Section OfSeq.
-Context (E : identType) (L : eqType) (bot : L). 
-Implicit Types (p : lfspreposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : lfspreposet E L).
 Implicit Types (ls : seq L).
 
 Definition of_seq ls := 
   let fE  := [fset e | e in nfresh \i0 (size ls)] in 
   let lab := fun e : fE => (nth bot ls (encode (val e))) in
   let ca  := fun e1 e2 : E => e1 <=^i e2 in
-  @build_cov E L bot fE lab ca.
+  @build_cov E L fE lab ca.
 
 Variable (ls : seq L).
 Hypothesis (lsD : bot \notin ls).
@@ -1045,9 +1039,9 @@ Lemma of_seq_nth_defined :
     nth bot ls (@encode E (val e)) != bot.
 Proof.
   move: lsD=> /negP nbl [/= ?].
-  rewrite ?inE /=; encodify=> ?.
+  rewrite ?inE /=; encodify; rewrite addn0=> ?.
   apply/negP; move: nbl=> /[swap]/eqP<-.
-  apply; apply/mem_nth; lia.
+  by apply; apply/mem_nth. 
 Qed.
 
 Lemma of_seq_eventset : 
@@ -1175,12 +1169,12 @@ Proof. move=> e1 e2; rewrite !of_seq_fin_caE /=; exact/le_total. Qed.
 
 End OfSeq.
 
-Arguments of_seq E L bot : clear implicits.
+Arguments of_seq E L : clear implicits.
 
 Section InterRel.
-Context (E : identType) (L : eqType) (bot : L). 
+Context (E : identType) (L : botType).
 Implicit Types (r : rel E).
-Implicit Types (p : lfspreposet E L bot).
+Implicit Types (p : lfspreposet E L).
 
 (* TODO: perhaps, we should define intersection for preorders only?
  *   Then we would have homogeneous binary operation, 
@@ -1193,7 +1187,7 @@ Implicit Types (p : lfspreposet E L bot).
  *            
  *)
 Definition inter_rel r p := 
-  @build_cov E L bot _ (fin_lab p) (r ⊓ (fs_ca p)).
+  @build_cov E L _ (fin_lab p) (r ⊓ (fs_ca p)).
 
 (* Lemma inter_rel_finsupp r p :  *)
 (*   lfsp_eventset (inter_rel r p) = lfsp_eventset p. *)
@@ -1218,7 +1212,7 @@ Proof.
   by move=> /sub_rel_liftP[[>[[>[? /= <- <-]]]]].
 Qed.
 
-Variables (r : rel E) (p : lfspreposet E L bot).
+Variables (r : rel E) (p : lfspreposet E L).
 Hypothesis (refl  : reflexive r).
 Hypothesis (trans : transitive r).
 Hypothesis (supcl : supp_closed p).
@@ -1254,18 +1248,18 @@ Qed.
 End InterRel.
 
 Section Restrict.
-Context (E : identType) (L : eqType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (P : pred E).
-Implicit Types (p : lfspreposet E L bot).
+Implicit Types (p : lfspreposet E L).
 
-Definition restrict P p : lfspreposet E L bot :=
+Definition restrict P p : lfspreposet E L :=
   (* TODO: there should be a simpler solution... *)
   let fE  := [fset e in lfsp_eventset p | P e] in
   let lab := (fun e : fE => fs_lab p (val e)) in
   let ca  := (eq_op ⊔ (P × P)) ⊓ (fs_ca p) in
-  @build_cov E L bot _ lab ca.
+  @build_cov E L _ lab ca.
 
-Variables (P : pred E) (p : lfspreposet E L bot).
+Variables (P : pred E) (p : lfspreposet E L).
 Hypothesis (supcl : supp_closed p).
 Hypothesis (acyc  : acyclic (fin_ica p)).
 
@@ -1339,17 +1333,17 @@ End Restrict.
 
 
 Section Relabel.
-Context (E : identType) (L1 : eqType) (L2 : eqType) (bot1 : L1) (bot2 : L2). 
+Context (E : identType) (L1 : botType) (L2 : botType).
 Implicit Types (f : L1 -> L2).
-Implicit Types (p : lfspreposet E L1 bot1).
+Implicit Types (p : lfspreposet E L1).
 
-Definition relabel f p : lfspreposet E L2 bot2 :=
+Definition relabel f p : lfspreposet E L2 :=
   [fsfun e in finsupp p => (f (fs_lab p e), fs_rcov p e)].
 
-Variables (f : L1 -> L2) (p : lfspreposet E L1 bot1).
+Variables (f : L1 -> L2) (p : lfspreposet E L1).
 (* TODO: use inhtype to get rid of explicit bot arguments... *)
-Hypothesis (fbot : bot_preserving bot1 bot2 f).
-Hypothesis (fsupp : finsupp_preserving bot2 p f).
+Hypothesis (fbot : {homo bot f}).
+Hypothesis (fsupp : finsupp_preserving p f).
 
 (* TODO: refactor this precondition? *)
 (* Hypothesis (flabD : forall e, let l := fs_lab p e in (l == bot1) = (f l == bot2)). *)
@@ -1429,11 +1423,10 @@ Module lFsPoset.
 
 Module Export Def.
 Section Def. 
-Context (E : identType) (L : eqType).
-Variable (bot : L).
+Context (E : identType) (L : botType).
 
 Structure lfsposet : Type := mklFsPoset {
-  lfsposet_val :> lfspreposet E L bot ; 
+  lfsposet_val :> lfspreposet E L ; 
   _ : let p := lfsposet_val in 
       supp_closed p && acyclic (fin_ica p)
 }.
@@ -1451,36 +1444,36 @@ Proof. by move: (valP p)=> /andP[]. Qed.
 End Def.
 End Def.
 
-Arguments lfsposet E L bot : clear implicits.
+Arguments lfsposet E L : clear implicits.
 
 Module Export Instances.
 Section Instances. 
 
-Definition lfsposet_eqMixin E L bot := 
-  Eval hnf in [eqMixin of (lfsposet E L bot) by <:].
-Canonical lfinposet_eqType E L bot := 
-  Eval hnf in EqType (lfsposet E L bot) (@lfsposet_eqMixin E L bot).
+Definition lfsposet_eqMixin E L := 
+  Eval hnf in [eqMixin of (lfsposet E L) by <:].
+Canonical lfinposet_eqType E L := 
+  Eval hnf in EqType (lfsposet E L) (@lfsposet_eqMixin E L).
 
-Definition lfsposet_choiceMixin E (L : choiceType) bot :=
-  Eval hnf in [choiceMixin of (lfsposet E L bot) by <:].
-Canonical lfsposet_choiceType E (L : choiceType) bot :=
-  Eval hnf in ChoiceType (lfsposet E L bot) (@lfsposet_choiceMixin E L bot).
+Definition lfsposet_choiceMixin E L :=
+  Eval hnf in [choiceMixin of (lfsposet E L) by <:].
+Canonical lfsposet_choiceType E L :=
+  Eval hnf in ChoiceType (lfsposet E L) (@lfsposet_choiceMixin E L).
 
-Definition lfsposet_countMixin E (L : countType) bot :=
-  Eval hnf in [countMixin of (@lfsposet E L bot) by <:].
-Canonical lfsposet_countType E (L : countType) bot :=
-  Eval hnf in CountType (lfsposet E L bot) (@lfsposet_countMixin E L bot).
+(* Definition lfsposet_countMixin E (L : countType) bot := *)
+(*   Eval hnf in [countMixin of (@lfsposet E L bot) by <:]. *)
+(* Canonical lfsposet_countType E (L : countType) bot := *)
+(*   Eval hnf in CountType (lfsposet E L bot) (@lfsposet_countMixin E L bot). *)
 
-Canonical subFinfun_subCountType E (L : countType) bot :=
-  Eval hnf in [subCountType of (lfsposet E L bot)].
+(* Canonical subFinfun_subCountType E (L : countType) bot := *)
+(*   Eval hnf in [subCountType of (lfsposet E L bot)]. *)
 
 End Instances.
 End Instances.
 
 Section BuildCov.
-Context (E : identType) (L : eqType) (bot : L). 
+Context (E : identType) (L : botType).
 Context (fE : {fset E}).
-Implicit Types (p : lfsposet E L bot).
+Implicit Types (p : lfsposet E L).
 Implicit Types (lab : fE -> L) (ica : rel fE) (ca : rel E).
 
 Variables (lab : fE -> L) (ca : rel E).
@@ -1490,7 +1483,7 @@ Hypothesis ca_anti  : antisymmetric ca.
 Hypothesis ca_trans : transitive ca.
 
 Lemma build_covP : 
-  let p := lFsPrePoset.build_cov bot lab ca in
+  let p := lFsPrePoset.build_cov lab ca in
   supp_closed p && acyclic (fin_ica p).
 Proof.
   apply/andP; split=> //; last first.
@@ -1507,12 +1500,12 @@ End BuildCov.
 
 
 Section Empty.
-Context (E : identType) (L : eqType) (bot : L). 
-Implicit Types (p : lfspreposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : lfspreposet E L).
 
 (* TODO: rename? *)
 Lemma emptyP : 
-  let p := @lFsPrePoset.empty E L bot in
+  let p := @lFsPrePoset.empty E L in
   supp_closed p && acyclic (fin_ica p).
 Proof.
   apply/andP; split.
@@ -1520,20 +1513,20 @@ Proof.
   exact/lFsPrePoset.empty_acyclic.
 Qed.
 
-Definition empty : lfsposet E L bot := 
+Definition empty : lfsposet E L := 
   mklFsPoset emptyP.
 
 End Empty.
 
-Arguments empty E L bot : clear implicits.
+Arguments empty E L : clear implicits.
 
 Section OfSeq.
-Context (E : identType) (L : eqType) (bot : L). 
-Implicit Types (p : lfspreposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : lfspreposet E L).
 Implicit Types (ls : seq L).
 
 Lemma of_seqP ls : bot \notin ls -> 
-  let p := lFsPrePoset.of_seq E L bot ls in
+  let p := lFsPrePoset.of_seq E L ls in
   supp_closed p && acyclic (fin_ica p).
 Proof.
   move=> labD; apply/andP; split.
@@ -1541,17 +1534,17 @@ Proof.
   exact/lFsPrePoset.of_seq_acyclic.
 Qed.
 
-Definition of_seq ls : lfsposet E L bot := 
+Definition of_seq ls : lfsposet E L := 
   if bot \notin ls =P true is ReflectT nbl then
     mklFsPoset (of_seqP nbl)
-  else empty E L bot.
+  else empty E L.
 
 Lemma of_seq_valE ls : 
   val (of_seq ls) = 
     if (bot \notin ls) then 
-      lFsPrePoset.of_seq E L bot ls
+      lFsPrePoset.of_seq E L ls
     else 
-      lFsPrePoset.empty E L bot.
+      lFsPrePoset.empty E L.
 Proof. by case: ifP; rewrite /of_seq; case: eqP=> //= ->. Qed.
 
 Lemma of_seq_size ls : 
@@ -1612,8 +1605,8 @@ End OfSeq.
 
 (* TODO: move to pomset_lts.v (by analogy with add_event)? *)
 Section DeleteMax.
-Context (E : identType) (L : eqType) (bot : L).
-Context (p : lfsposet E L bot) (x : E).
+Context (E : identType) (L : botType).
+Context (p : lfsposet E L) (x : E).
 
 (* TODO: rename remove_event (by analogy with add_event)? *)
 Definition delete_pre := [fsfun p without x].
@@ -1703,7 +1696,7 @@ Proof. by rewrite delete_supp_closed delete_acyclic. Qed.
 End DeletePre.
 
 Definition delete :=
-  if eqP is ReflectT pf then mklFsPoset (deleteP pf) else lFsPoset.empty E L bot.
+  if eqP is ReflectT pf then mklFsPoset (deleteP pf) else lFsPoset.empty E L.
 
 Definition lfsp_delE: 
   [forall y : lfsp_eventset p, ~~ fs_ica p x (val y)] ->
@@ -1718,11 +1711,11 @@ Qed.
 
 End DeleteMax.
 
-Arguments of_seq E L bot : clear implicits.
+Arguments of_seq E L : clear implicits.
 
 Section InterRel.
-Context (E : identType) (L : eqType) (bot : L). 
-Implicit Types (p : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : lfsposet E L).
 
 Variable (r : rel E).
 Hypothesis (refl  : reflexive r).
@@ -1743,21 +1736,21 @@ Definition inter_rel p := mklFsPoset (inter_relP p).
 
 End InterRel.
 
-Arguments inter_rel {E L bot} r. 
+Arguments inter_rel {E L} r. 
 
 Section Inter.
-Context (E : identType) (L : eqType) (bot : L). 
-Implicit Types (p q : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p q : lfsposet E L).
 
 Definition inter p q := 
-  inter_rel (fs_ca p) (fs_ca_refl p) (@fs_ca_trans _ _ _ p) q.
+  inter_rel (fs_ca p) (fs_ca_refl p) (@fs_ca_trans _ _ p) q.
 
 End Inter.
 
 Section Restrict.
-Context (E : identType) (L : eqType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (P : pred E).
-Implicit Types (p : lfsposet E L bot).
+Implicit Types (p : lfsposet E L).
 
 Lemma restrictP P p :  
   let q := lFsPrePoset.restrict P p in
@@ -1779,17 +1772,17 @@ Proof. done. Qed.
 End Restrict.
 
 Section Relabel.
-Context (E : identType) (L1 : eqType) (L2 : eqType) (bot1 : L1) (bot2 : L2). 
+Context (E : identType) (L1 : botType) (L2 : botType).
 Implicit Types (f : L1 -> L2). 
-Implicit Types (p : lfsposet E L1 bot1).
+Implicit Types (p : lfsposet E L1).
 
 (* Hypothesis (flabD : forall e, let l := fs_lab p e in (l == bot1) = (f l == bot2)). *)
 (* Hypothesis (flabD : forall l, (l == bot1) = (f l == bot2)). *)
 (* Hypothesis (labD : lab_defined p). *)
 
 Lemma relabelP f p : 
-  bot_preserving bot1 bot2 f -> finsupp_preserving bot2 p f -> 
-  let q := @lFsPrePoset.relabel E L1 L2 bot1 bot2 f p in
+  {homo bot f} -> finsupp_preserving p f -> 
+  let q := @lFsPrePoset.relabel E L1 L2 f p in
   supp_closed q && acyclic (fin_ica q).
 Proof.
   move=> fbot fsupp.
@@ -1801,19 +1794,19 @@ Proof.
 Qed.
 
 Definition relabel f p :=
-  match (bot_preserving bot1 bot2 f) && (finsupp_preserving bot2 p f) =P true with
-  | ReflectF _  => lFsPoset.empty E L2 bot2
+  match {homo bot f} && (finsupp_preserving p f) =P true with
+  | ReflectF _  => lFsPoset.empty E L2 
   | ReflectT pf =>
     let: conj fbot fsupp := andP pf in
     mklFsPoset (relabelP fbot fsupp)
   end.
 
-Variable (f : L1 -> L2) (p : lfsposet E L1 bot1).
-Hypothesis (fbot : bot_preserving bot1 bot2 f).
-Hypothesis (fsupp : finsupp_preserving bot2 p f).
+Variable (f : L1 -> L2) (p : lfsposet E L1).
+Hypothesis (fbot : {homo bot f}).
+Hypothesis (fsupp : finsupp_preserving p f).
 
 Lemma relabel_valE : 
-  val (relabel f p) = @lFsPrePoset.relabel E L1 L2 bot1 bot2 f p.
+  val (relabel f p) = @lFsPrePoset.relabel E L1 L2 f p.
 Proof. 
   rewrite /relabel; case: eqP=> [pf|] //=.
   - by case: (andP pf). 
@@ -1822,19 +1815,19 @@ Qed.
 
 End Relabel.
 
-Arguments relabel {E L1 L2 bot1 bot2} f p.
+Arguments relabel {E L1 L2} f p.
 
 Module Export POrder.
 Section POrder.
-Context {E : identType} {L : eqType}.
-Variable (bot : L) (p : lfsposet E L bot).
+Context {E : identType} {L : botType}.
+Variable (bot : L) (p : lfsposet E L).
 
 Definition lfsposet_porderMixin := 
   @LePOrderMixin E (fs_ca p) (fs_sca p) 
     (fs_sca_def p) 
     (fs_ca_refl p) 
     (fs_ca_antisym (lfsp_acyclic p))
-    (@fs_ca_trans _ _ _ p). 
+    (@fs_ca_trans _ _ p). 
 
 Definition lfsposet_porderType := 
   POrderType tt E lfsposet_porderMixin.
@@ -1871,8 +1864,8 @@ End POrder.
 
 Module Export FinPOrder.
 Section FinPOrder.
-Context (E : identType) (L : eqType) (bot : L).
-Variable (p : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Variable (p : lfsposet E L).
 
 Lemma fin_sca_def e1 e2 : 
   fin_sca p e1 e2 = (e2 != e1) && (fin_ca p e1 e2).
@@ -1927,8 +1920,8 @@ End Syntax.
 
 Module Export Theory.
 Section Theory.
-Context {E : identType} {L : eqType} {bot : L}.
-Implicit Types (p q : lfsposet E L bot).
+Context {E : identType} {L : botType}.
+Implicit Types (p q : lfsposet E L).
 
 Lemma fs_labE p : 
   lab =1 fs_lab p :> ([Event of p] -> L).  
@@ -1965,8 +1958,8 @@ Import lPoset.Syntax.
 
 Module Export Hom.
 Section Hom.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 Implicit Types (f : E1 -> E2).
 
 Definition is_hom f p q := 
@@ -1975,7 +1968,7 @@ Definition is_hom f p q :=
     & {in (lfsp_eventset p) &, {homo f : e1 e2 / e1 <= e2}}
   ].
 
-Variables (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Variables (p : lfsposet E1 L) (q : lfsposet E2 L).
 Variables (f : E1 -> E2) (ff : {ffun [FinEvent of p] -> [FinEvent of q]}).
 Hypothesis (feq : forall e : lfsp_eventset p, f (val e) = val (ff e)).
 
@@ -2074,11 +2067,11 @@ Proof. by rewrite ffunE. Qed.
 
 End Hom.
 
-Arguments is_hom {_ _ _ _} _ _.
+Arguments is_hom {_ _ _} _ _.
 
 Section hPreOrder.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 
 Definition hom_le p q := 
   let EP := [FinEvent of p] in
@@ -2103,20 +2096,20 @@ Proof. move=> [] fmon ?; by rewrite -?fs_labNbot -?fs_labE fmon. Qed.
 End hPreOrder.
 
 Section PreOrder.
-Context {E : identType} {L : eqType} {bot : L}.
-Implicit Types (p q : lfsposet E L bot).
+Context {E : identType} {L : botType}.
+Implicit Types (p q : lfsposet E L).
 
 (* TODO: this relation should also be heterogeneous? *)
-Definition hom_lt : rel (lfsposet E L bot) := 
+Definition hom_lt : rel (lfsposet E L) := 
   fun p q => (q != p) && (hom_le p q).
 
 Lemma hom_lt_def p q : hom_lt p q = (q != p) && (hom_le p q).
 Proof. done. Qed.
 
-Lemma hom_le_refl : reflexive (@hom_le E E L bot). 
+Lemma hom_le_refl : reflexive (@hom_le E E L). 
 Proof. move=> ?; exact/lFinPoset.Hom.hom_le_refl. Qed.
 
-Lemma hom_le_trans : transitive (@hom_le E E L bot). 
+Lemma hom_le_trans : transitive (@hom_le E E L). 
 Proof. move=> ??? /[swap]; exact/lFinPoset.Hom.hom_le_trans. Qed.
 
 Lemma is_hom_id_finsuppE p q : 
@@ -2138,8 +2131,8 @@ End Hom.
 
 Module Export iHom.
 Section iHom.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 Implicit Types (f : E1 -> E2).
 
 Definition is_ihom f p q := 
@@ -2149,7 +2142,7 @@ Definition is_ihom f p q :=
     & {in (lfsp_eventset p) &, injective f}
   ].
 
-Variables (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Variables (p : lfsposet E1 L) (q : lfsposet E2 L).
 Variables (f : E1 -> E2) (ff : {ffun [FinEvent of p] -> [FinEvent of q]}).
 Hypothesis (feq : forall e : lfsp_eventset p, f (val e) = val (ff e)).
 
@@ -2193,11 +2186,11 @@ Qed.
 
 End iHom.
 
-Arguments is_ihom {_ _ _ _} _ _.
+Arguments is_ihom {_ _ _} _ _.
 
 Section hPreOrder.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 
 (* TODO: rename bhom_preord? *)
 Definition ihom_le p q := 
@@ -2226,20 +2219,20 @@ Qed.
 End hPreOrder.
 
 Section PreOrder.
-Context (E : identType) (L : eqType) (bot : L).
-Implicit Types (p q : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p q : lfsposet E L).
 
 (* TODO: this relation should also be heterogeneous? *)
-Definition ihom_lt : rel (lfsposet E L bot) := 
+Definition ihom_lt : rel (lfsposet E L) := 
   fun p q => (q != p) && (ihom_le p q).
 
 Lemma ihom_lt_def p q : ihom_lt p q = (q != p) && (ihom_le p q).
 Proof. done. Qed.
 
-Lemma ihom_le_refl : reflexive (@ihom_le E E L bot). 
+Lemma ihom_le_refl : reflexive (@ihom_le E E L). 
 Proof. move=> ?; exact/lFinPoset.iHom.ihom_le_refl. Qed.
 
-Lemma ihom_le_trans : transitive (@ihom_le E E L bot). 
+Lemma ihom_le_trans : transitive (@ihom_le E E L). 
 Proof. move=> ??? /[swap]; exact/lFinPoset.iHom.ihom_le_trans. Qed.
 
 End PreOrder.
@@ -2249,8 +2242,8 @@ End iHom.
 
 Module Export bHom.
 Section bHom.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 Implicit Types (f : E1 -> E2).
 
 Definition is_bhom f p q := 
@@ -2260,7 +2253,7 @@ Definition is_bhom f p q :=
     & {on (lfsp_eventset q)  , bijective f}
   ].
 
-Variables (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Variables (p : lfsposet E1 L) (q : lfsposet E2 L).
 Variables (f : E1 -> E2) (ff : {ffun [FinEvent of p] -> [FinEvent of q]}).
 Hypothesis (feq : forall e : lfsp_eventset p, f (val e) = val (ff e)).
 
@@ -2323,11 +2316,11 @@ Qed.
 
 End bHom.
 
-Arguments is_bhom {_ _ _ _} _ _.
+Arguments is_bhom {_ _ _} _ _.
 
 Section hPreOrder.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 
 (* TODO: rename bhom_preord? *)
 Definition bhom_le p q := 
@@ -2363,23 +2356,23 @@ Qed.
 End hPreOrder.
 
 Section PreOrder.
-Context (E : identType) (L : eqType) (bot : L).
-Implicit Types (p q : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p q : lfsposet E L).
 
 (* TODO: this relation should also be heterogeneous? *)
-Definition bhom_lt : rel (lfsposet E L bot) := 
+Definition bhom_lt : rel (lfsposet E L) := 
   fun p q => (q != p) && (bhom_le p q).
 
-Definition lin E L bot (p : lfsposet E L bot) : pred (seq L) :=
-  [pred ls | bhom_le (lFsPoset.of_seq E L bot ls) p].
+Definition lin E L (p : lfsposet E L) : pred (seq L) :=
+  [pred ls | bhom_le (lFsPoset.of_seq E L ls) p].
 
 Lemma bhom_lt_def p q : bhom_lt p q = (q != p) && (bhom_le p q).
 Proof. done. Qed.
 
-Lemma bhom_le_refl : reflexive (@bhom_le E E L bot). 
+Lemma bhom_le_refl : reflexive (@bhom_le E E L). 
 Proof. move=> ?; exact/lFinPoset.bHom.bhom_le_refl. Qed.
 
-Lemma bhom_le_trans : transitive (@bhom_le E E L bot). 
+Lemma bhom_le_trans : transitive (@bhom_le E E L). 
 Proof. move=> ??? /[swap]; exact/lFinPoset.bHom.bhom_le_trans. Qed.
 
 Lemma is_bhom_idE p q  : 
@@ -2396,8 +2389,8 @@ End bHom.
 
 Module Export Emb.
 Section Emb.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 Implicit Types (f : E1 -> E2).
 
 Definition is_emb f p q := 
@@ -2406,7 +2399,7 @@ Definition is_emb f p q :=
     & {in (lfsp_eventset p) &, {mono f : e1 e2 / e1 <= e2}}
   ].
 
-Variables (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Variables (p : lfsposet E1 L) (q : lfsposet E2 L).
 Variables (f : E1 -> E2) (ff : {ffun [FinEvent of p] -> [FinEvent of q]}).
 Hypothesis (feq : forall e : lfsp_eventset p, f (val e) = val (ff e)).
 
@@ -2436,11 +2429,11 @@ Qed.
 
 End Emb.
 
-Arguments is_emb {_ _ _ _} _ _.
+Arguments is_emb {_ _ _} _ _.
 
 Section hPreOrder.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 
 Definition emb_le p q := 
   let EP := [FinEvent of p] in
@@ -2511,20 +2504,20 @@ Qed.
 End hPreOrder.
 
 Section PreOrder.
-Context (E : identType) (L : eqType) (bot : L).
-Implicit Types (p q : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p q : lfsposet E L).
 
 (* TODO: this relation should also be heterogeneous? *)
-Definition emb_lt : rel (lfsposet E L bot) := 
+Definition emb_lt : rel (lfsposet E L) := 
   fun p q => (q != p) && (emb_le p q).
 
 Lemma emb_lt_def p q : emb_lt p q = (q != p) && (emb_le p q).
 Proof. done. Qed.
 
-Lemma emb_le_refl : reflexive (@emb_le E E L bot). 
+Lemma emb_le_refl : reflexive (@emb_le E E L). 
 Proof. move=> ?; exact/lFinPoset.Emb.emb_le_refl. Qed.
 
-Lemma emb_le_trans : transitive (@emb_le E E L bot). 
+Lemma emb_le_trans : transitive (@emb_le E E L). 
 Proof. move=> ??? /[swap]; exact/lFinPoset.Emb.emb_le_trans. Qed.
 
 End PreOrder.
@@ -2534,8 +2527,8 @@ End Emb.
 
 Module Export Iso.
 Section Iso.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 Implicit Types (f : E1 -> E2).
 
 Definition is_iso f p q := 
@@ -2545,7 +2538,7 @@ Definition is_iso f p q :=
     & {on (lfsp_eventset q)  , bijective f}
   ].
 
-Variables (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Variables (p : lfsposet E1 L) (q : lfsposet E2 L).
 Variables (f : E1 -> E2) (ff : {ffun [FinEvent of p] -> [FinEvent of q]}).
 Hypothesis (feq : forall e : lfsp_eventset p, f (val e) = val (ff e)).
 
@@ -2586,8 +2579,8 @@ Qed.
 End Iso.
 
 Section hEquiv.
-Context {E1 E2 : identType} {L : eqType} {bot : L}.
-Implicit Types (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Context {E1 E2 : identType} {L : botType}.
+Implicit Types (p : lfsposet E1 L) (q : lfsposet E2 L).
 
 Definition iso_eqv p q := 
   let EP := [FinEvent of p] in
@@ -2629,7 +2622,7 @@ Lemma iso_eqv_size p q :
 Proof. by move=> /iso_bhom_le /bhom_le_size. Qed.
 
 Lemma bhom_factor p q : bhom_le p q -> 
-  exists2 q' : lfsposet E1 L bot, iso_eqv q' q & is_hom id q' p.
+  exists2 q' : lfsposet E1 L, iso_eqv q' q & is_hom id q' p.
 Proof.
   case/bhom_leP=> f [labf homf [/= g K K']]. 
   set fE := lfsp_eventset p.
@@ -2638,7 +2631,7 @@ Proof.
     (e1 == e2) || 
     [&& fs_ca q (g e1) (g e2), e1 \in lfsp_eventset p & e2 \in lfsp_eventset p].
   have [: a1 a2 a3 a4] @q' := 
-    @lFsPoset.build_cov E1 L bot fE fl ca a1 a2 a3 a4.
+    @lFsPoset.build_cov E1 L fE fl ca a1 a2 a3 a4.
   - by case=> e ein; rewrite /= /fl -labf K' //= fs_labE fs_labNbot. 
   - by move=> ?; rewrite /ca eqxx.
   - move=> e1 e2 /andP[] /orP[/eqP-> //|/and3P[+ e1In e2In]].
@@ -2649,7 +2642,7 @@ Proof.
     move=>/(_ e2In e1In)/[swap].
     move=> ??; suff: e1 = e2 :> [Event of p] by done.
     exact/le_anti/andP.
-  - set ft := (@fs_ca_trans _ _ _ q).
+  - set ft := (@fs_ca_trans _ _ q).
     move=>>; rewrite /ca => /orP[/eqP->//|/and3P[/[dup] fc /ft tr i1 i2]].
     move/orP=>[/eqP<-|]; rewrite ?fc ?i1 i2 //=.
     by move/andP=> [/tr->]->.
@@ -2685,7 +2678,7 @@ Definition upd_iso (f : E1 -> E2) p q e' x y e :=
  if e \in lfsp_eventset p then f e else if e == x then y else e'.
 
 Section Update.
-Variables (f : E1 -> E2) (p : lfsposet E1 L bot) (q : lfsposet E2 L bot).
+Variables (f : E1 -> E2) (p : lfsposet E1 L) (q : lfsposet E2 L).
 Variables (e' : E2) (x : E1) (y : E2).
 
 Hypothesis (en' : e' \notin lfsp_eventset q).
@@ -2741,17 +2734,17 @@ End Update.
 End hEquiv.
 
 Section Equiv.
-Context (E : identType) (L : eqType) (bot : L).
-Implicit Types (p q : lfsposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p q : lfsposet E L).
 
 (* TODO: generalize the proofs to arbitary `T -> T -> Type`? *)
-Lemma iso_eqv_refl : reflexive (@iso_eqv E E L bot).
+Lemma iso_eqv_refl : reflexive (@iso_eqv E E L).
 Proof. 
   move=> p; apply/lFinPoset.Iso.iso_eqvP. 
   exists; exact/[iso of idfun]. 
 Qed.
 
-Lemma iso_eqv_sym : symmetric (@iso_eqv E E L bot).
+Lemma iso_eqv_sym : symmetric (@iso_eqv E E L).
 Proof. 
   move=> p q.
   apply/idP/idP=> /lFinPoset.Iso.iso_eqvP [f]; 
@@ -2759,7 +2752,7 @@ Proof.
     exists; exact/[iso of bhom_inv f].
 Qed.
 
-Lemma iso_eqv_trans : transitive (@iso_eqv E E L bot).
+Lemma iso_eqv_trans : transitive (@iso_eqv E E L).
 Proof. 
   rewrite /iso_eqv=> p q r.
   move=> /lFinPoset.Iso.iso_eqvP [f] /lFinPoset.Iso.iso_eqvP [g]. 
@@ -2809,13 +2802,13 @@ Import lFsPoset.Syntax.
 
 Module Export Def.
 Section Def.  
-Context {E : identType} {L : choiceType} {bot : L}.
+Context {E : identType} {L : botType}.
 
 Canonical iso_equiv_rel := 
   EquivRel iso_eqv 
-    (@iso_eqv_refl E L bot) 
-    (@iso_eqv_sym E L bot) 
-    (@iso_eqv_trans E L bot).
+    (@iso_eqv_refl E L) 
+    (@iso_eqv_sym E L) 
+    (@iso_eqv_trans E L).
 
 Definition pomset := {eq_quot iso_eqv}.
 
@@ -2824,11 +2817,11 @@ Canonical pomset_eqType := [eqType of pomset].
 Canonical pomset_choiceType := [choiceType of pomset].
 Canonical pomset_eqQuotType := [eqQuotType iso_eqv of pomset].
 
-Definition pom : lfsposet E L bot -> pomset := \pi.
+Definition pom : lfsposet E L -> pomset := \pi.
 
 Implicit Types (p : pomset).
 
-Coercion lfsposet_of p : lfsposet E L bot := repr p.
+Coercion lfsposet_of p : lfsposet E L := repr p.
 
 (* TODO: specialize lemma event further? use is_iso equivalence directly? *)
 Lemma pomP q : 
@@ -2838,64 +2831,64 @@ Proof. by case: piP. Qed.
 End Def.
 End Def.
 
-Arguments pomset E L bot : clear implicits.
+Arguments pomset E L : clear implicits.
 
 Section OfSeq.
-Context (E : identType) (L : choiceType) (bot : L). 
-Implicit Types (p : pomset E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : pomset E L).
 Implicit Types (ls : seq L).
 
-Definition of_seq ls : pomset E L bot := 
-  pom (@lFsPoset.of_seq E L bot ls).
+Definition of_seq ls : pomset E L := 
+  pom (@lFsPoset.of_seq E L ls).
 
 End OfSeq.
 
 Section InterRel.
-Context (E : identType) (L : choiceType) (bot : L). 
-Implicit Types (p : pomset E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : pomset E L).
 
 Variable (r : rel E).
 Hypothesis (refl  : reflexive r).
 Hypothesis (trans : transitive r).
 
-Definition inter_rel p : pomset E L bot := 
+Definition inter_rel p : pomset E L := 
   \pi (lFsPoset.inter_rel r refl trans p).
 
 End InterRel.
 
-Arguments inter_rel {E L bot} r. 
+Arguments inter_rel {E L} r. 
 
 Section Inter.
-Context (E : identType) (L : choiceType) (bot : L). 
-Implicit Types (p q : pomset E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p q : pomset E L).
 
-Definition inter p q : pomset E L bot := 
+Definition inter p q : pomset E L := 
   \pi (lFsPoset.inter p q).
 
 End Inter.
 
 Section Restrict.
-Context (E : identType) (L : choiceType) (bot : L). 
+Context (E : identType) (L : botType).
 Implicit Types (P : pred E).
-Implicit Types (p q : pomset E L bot).
+Implicit Types (p q : pomset E L).
 
-Definition restrict P p : pomset E L bot := 
+Definition restrict P p : pomset E L := 
   \pi (lFsPoset.restrict P p).
 
 End Restrict.
 
 
 Section Relabel.
-Context (E : identType) (L1 L2 : choiceType) (bot1 : L1) (bot2 : L2). 
+Context (E : identType) (L1 L2 : botType).
 Implicit Types (f : L1 -> L2).
-Implicit Types (p : pomset E L1 bot1).
+Implicit Types (p : pomset E L1).
 
-Definition relabel f p : pomset E L2 bot2 := 
-  \pi (@lFsPoset.relabel E L1 L2 bot1 bot2 f p).
+Definition relabel f p : pomset E L2 := 
+  \pi (@lFsPoset.relabel E L1 L2 f p).
 
 End Relabel.
 
-Arguments relabel {E L1 L2 bot1 bot2} f p.
+Arguments relabel {E L1 L2} f p.
 
 Import lPoset.Syntax.
 Import lFsPoset.Syntax.
@@ -2903,9 +2896,9 @@ Import lFsPoset.Syntax.
 Module Export iHom.
 Module Export POrder.
 Section POrder.
-Implicit Types (E : identType) (L : choiceType).
+Implicit Types (E : identType) (L : botType).
 
-Lemma pom_ihom_le E1 E2 L bot (p : lfsposet E1 L bot) (q : lfsposet E2 L bot) :
+Lemma pom_ihom_le E1 E2 L (p : lfsposet E1 L) (q : lfsposet E2 L) :
   ihom_le (repr (pom p)) (repr (pom q)) = ihom_le p q.
 Proof.
   rewrite /ihom_le. 
@@ -2916,11 +2909,11 @@ Proof.
   exact/[ihom of [iso of (bhom_inv g)] \o h \o f].
 Qed.
 
-Context {E : identType} {L : choiceType} {bot : L}.
-Implicit Types (p q : pomset E L bot). 
+Context {E : identType} {L : botType}.
+Implicit Types (p q : pomset E L). 
 
 Lemma pom_ihom_mono :
-  {mono (@pom E L bot) : p q / ihom_le p q >-> ihom_le (repr p) (repr q)}.
+  {mono (@pom E L) : p q / ihom_le p q >-> ihom_le (repr p) (repr q)}.
 Proof. exact/pom_ihom_le. Qed.
 
 Canonical ihom_le_quot_mono2 := PiMono2 pom_ihom_mono.
@@ -2934,9 +2927,9 @@ End iHom.
 Module Export bHom.
 Module Export POrder.
 Section POrder.
-Implicit Types (E : identType) (L : choiceType).
+Implicit Types (E : identType) (L : botType).
 
-Lemma pom_bhom_le E1 E2 L bot (p : lfsposet E1 L bot) (q : lfsposet E2 L bot) :
+Lemma pom_bhom_le E1 E2 L (p : lfsposet E1 L) (q : lfsposet E2 L) :
   bhom_le (repr (pom p)) (repr (pom q)) = bhom_le p q.
 Proof.
   rewrite /bhom_le. 
@@ -2947,7 +2940,7 @@ Proof.
   exact/[bhom of [iso of bhom_inv g] \o h \o f].
 Qed.
 
-Lemma pom_bhom_le1 E1 E2 L bot (p : lfsposet E1 L bot) (q : lfsposet E2 L bot) :
+Lemma pom_bhom_le1 E1 E2 L (p : lfsposet E1 L) (q : lfsposet E2 L) :
   bhom_le p (repr (pom q)) = bhom_le p q.
 Proof.
   rewrite /bhom_le. 
@@ -2958,33 +2951,33 @@ Proof.
   exact/[bhom of h \o f].
 Qed.
 
-Context {E : identType} {L : choiceType} {bot : L}.
-Implicit Types (p q : pomset E L bot). 
+Context {E : identType} {L : botType}.
+Implicit Types (p q : pomset E L). 
 
 Lemma pom_bhom_mono :
-  {mono (@pom E L bot) : p q / bhom_le p q >-> bhom_le (repr p) (repr q)}.
+  {mono (@pom E L) : p q / bhom_le p q >-> bhom_le (repr p) (repr q)}.
 Proof. exact/pom_bhom_le. Qed.
 
 Lemma pom_lin_mono l :
-  {mono (@pom E L bot) : p / l \in lin p >-> l \in lin (repr p)}.
+  {mono (@pom E L) : p / l \in lin p >-> l \in lin (repr p)}.
 Proof. exact/pom_bhom_le1. Qed.
 
 Canonical bhom_le_quote_mono2 := PiMono2 pom_bhom_mono.
 Canonical lin_quote_mono2 l := PiMono1 (pom_lin_mono l).
 
 Lemma pom_bhom_le_refl : 
-  reflexive (@bhom_le E E L bot : rel (pomset E L bot)). 
+  reflexive (@bhom_le E E L : rel (pomset E L)). 
 Proof. exact/bhom_le_refl. Qed.
 
 Lemma pom_bhom_le_antisym : 
-  antisymmetric (@bhom_le E E L bot : rel (pomset E L bot)). 
+  antisymmetric (@bhom_le E E L : rel (pomset E L)). 
 Proof. 
   move=> p q; rewrite -[p]reprK -[q]reprK !piE.
   move=> /andP[??]; exact/eqmodP/iso_bhom_le_antisym.
 Qed.
 
 Lemma pom_bhom_le_trans : 
-  transitive (@bhom_le E E L bot : rel (pomset E L bot)). 
+  transitive (@bhom_le E E L : rel (pomset E L)). 
 Proof. exact/bhom_le_trans. Qed.
 
 Lemma disp : unit. 
@@ -2992,12 +2985,12 @@ Proof. exact: tt. Qed.
 
 Definition pomset_bhomPOrderMixin := 
   @LePOrderMixin _ 
-    (@bhom_le E E L bot : rel (pomset E L bot)) 
+    (@bhom_le E E L : rel (pomset E L)) 
     (fun p q => (q != p) && (bhom_le p q))
     (fun p q => erefl) pom_bhom_le_refl pom_bhom_le_antisym pom_bhom_le_trans. 
 
 Canonical pomset_bhomPOrderType := 
-  POrderType disp (pomset E L bot) pomset_bhomPOrderMixin.
+  POrderType disp (pomset E L) pomset_bhomPOrderMixin.
 
 Lemma pom_bhom_leE p q : p <= q = bhom_le p q.
 Proof. done. Qed.
@@ -3008,10 +3001,10 @@ End bHom.
 
 Module Export Theory.
 Section Theory.
-Context {E : identType} {L : choiceType} (bot : L).
-Implicit Types (p q : pomset E L bot).
+Context {E : identType} {L : botType}.
+Implicit Types (p q : pomset E L).
 
-Lemma iso_eqv_pom (p : lfsposet E L bot) :
+Lemma iso_eqv_pom (p : lfsposet E L) :
   iso_eqv p (pom p).
 Proof. by rewrite -eqmodE piK. Qed.
 
@@ -3046,10 +3039,10 @@ Import lFsPoset.Syntax.
 
 Module Export Def.
 Section Def.  
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 
 Structure tomset : Type := mkTomset {
-  tomset_val :> pomset E L bot;
+  tomset_val :> pomset E L;
   _ : totalb (fin_ca tomset_val); 
 }.
 
@@ -3075,19 +3068,19 @@ Qed.
 End Def.
 End Def.
 
-Arguments tomset E L bot : clear implicits.
+Arguments tomset E L : clear implicits.
 
 
 Section OfSeq.
-Context (E : identType) (L : choiceType) (bot : L). 
-Implicit Types (p : lfspreposet E L bot).
+Context (E : identType) (L : botType).
+Implicit Types (p : lfspreposet E L).
 Implicit Types (ls : seq L).
 
 Lemma of_seq_total ls : 
-  let p := @Pomset.of_seq E L bot ls in
+  let p := @Pomset.of_seq E L ls in
   total (fin_ca p).   
 Proof. 
-  pose p := @lFsPoset.of_seq E L bot ls.
+  pose p := @lFsPoset.of_seq E L ls.
   rewrite /Pomset.of_seq=> /= e1 e2.
   move: (iso_eqv_pom p)=> /lFinPoset.Iso.iso_eqvP [f]. 
   move: (lFsPoset.of_seq_total (f e1) (f e2)).
@@ -3102,16 +3095,16 @@ End OfSeq.
 
 Module Export Theory.
 Section Theory.
-Context {E : identType} {L : choiceType} (bot : L).
-Implicit Types (t u : tomset E L bot).
+Context {E : identType} {L : botType}.
+Implicit Types (t u : tomset E L).
 
 Lemma tomset_labelsK : 
-  cancel (@lfsp_labels E L bot : tomset E L bot -> seq L) (@of_seq E L bot).
+  cancel (@lfsp_labels E L : tomset E L -> seq L) (@of_seq E L).
 Proof. 
   move=> t; apply/val_inj/esym/eqP=> /=.
   rewrite eqquot_piE iso_eqv_sym.
   apply/iso_eqvP.
-  pose u := lFsPoset.of_seq E L bot (lfsp_labels t).
+  pose u := lFsPoset.of_seq E L (lfsp_labels t).
   pose f : [Event of t] -> [Event of u] := 
     fun e => decode (lfsp_idx t e).
   move: (lfsp_labels_Nbot t)=> labD.

--- a/theories/concur/pomset.v
+++ b/theories/concur/pomset.v
@@ -214,7 +214,7 @@ Lemma fs_ca_scaE p e1 e2 :
   fs_ca p e1 e2 = (e1 == e2) || (fs_sca p e1 e2).
 Proof. rewrite /fs_sca -(@iker_qmk _ (fs_ca p)) //; exact/qmk_refl. Qed.
 
-Lemma lfsposet_eqP p q : 
+Lemma lfspreposet_eqP p q : 
   reflect ((fs_lab p =1 fs_lab q) * (fs_ica p =2 fs_ica q)) (p == q).
 Proof. 
   apply/(equivP idP); split=> [/eqP->|[]] //.
@@ -748,7 +748,7 @@ Definition build_cov lab ca : lfspreposet E L bot :=
   let ica : rel fE := cov (relpre val sca) in
   @build E L bot fE lab ica.
 
-Variables (lab : fE -> L) (ca : rel E).
+Variables  (lab : fE -> L) (ca : rel E).
 Hypothesis (labD : forall e, lab e != bot).
 Hypothesis (ca_refl  : reflexive ca).
 Hypothesis (ca_anti  : antisymmetric ca).
@@ -902,14 +902,19 @@ Qed.
 
 (* TODO: /end/ the following proofs should be simpler :( *)
 
-Lemma empty_eqP p : 
+Lemma empty_eqP p : supp_closed p -> 
   reflect (p = empty) (lfsp_size p == 0%N).
 Proof.
+  move=> supcl.
   apply/(equivP idP); split=> [|->]; last first. 
   - by rewrite fs_size_empty. 
   rewrite /lfsp_size=> /eqP/cardfs0_eq fE. 
-  admit.
-Admitted.
+  apply/eqP/lfspreposet_eqP; split=> >.
+  - rewrite fs_lab_empty fs_lab_bot ?fE //.
+  rewrite fs_ica_empty /fs_ica /=. 
+  apply/idP; move/supp_closedP: supcl. 
+  by move=> /[apply]; rewrite fE => [[]].
+Qed.
 
 Lemma empty_supp_closed : 
   supp_closed empty.

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -29,32 +29,32 @@ Local Open Scope pomset_scope.
 
 
 (* TODO: consider decidable/bool languages only? *)
-Notation pomlang E L bot := (pomset E L bot -> Prop).
+Notation pomlang E L := (pomset E L -> Prop).
 
 Module Export PomLang.
 Section PomLang.
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Context (S : ltsType L).
 Implicit Types (l : L) (s : S).
-Implicit Types (p : pomset E L bot).
+Implicit Types (p : pomset E L).
 
 (* TODO: this should be simplified *)
-Definition lts_pomlang s : pomlang E L bot := 
-  fun p => exists2 ls, p = @Pomset.of_seq E L bot ls & lts_lang s ls. 
+Definition lts_pomlang s : pomlang E L := 
+  fun p => exists2 ls, p = @Pomset.of_seq E L ls & lts_lang s ls. 
 
 (* TODO: for bool-languages it can be stated using {subsumes} notation *)
-Definition subsumes : pomlang E L bot -> pomlang E L bot -> Prop := 
+Definition subsumes : pomlang E L -> pomlang E L -> Prop := 
   fun P Q => forall p, P p -> exists q, Q q /\ bhom_le p q.
 
 (* TODO: for bool-languages it can be stated using {subsumes} notation *)
-Definition supports : pomlang E L bot -> pomlang E L bot -> Prop := 
+Definition supports : pomlang E L -> pomlang E L -> Prop := 
   fun P Q => forall p, P p -> exists q, Q q /\ bhom_le q p.
 
 (* for a given pomset p returns language consisting of 
  * restrictions of p onto its principal ideals, 
  * that is prefixes of events of p.  
  *)
-Definition pideal_lang p : pomlang E L bot := 
+Definition pideal_lang p : pomlang E L := 
   let pideals := [fset (pideal (e : [Event of p])) | e in finsupp p] in
   let qs := [fset (Pomset.restrict (mem (es : {fset E})) p) | es in pideals] in
   fun q => q \in qs.
@@ -71,11 +71,11 @@ Module Export AddEvent.
 
 Module Export Def.
 Section Def.  
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (l : L) (es : {fset E}).
-Implicit Types (p : lfspreposet E L bot).
+Implicit Types (p : lfspreposet E L).
 
-Definition lfspre_add_event l es p : lfspreposet E L bot := 
+Definition lfspre_add_event l es p : lfspreposet E L := 
   let e := lfsp_fresh p in
   [fsfun p with e |-> (l, es)].
 
@@ -84,9 +84,9 @@ End Def.
 
 Module Export Theory.
 Section Theory.  
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Variable (l : L) (es : {fset E}).
-Variable (p : lfspreposet E L bot).
+Variable (p : lfspreposet E L).
 
 Hypothesis (lD : l != bot).
 Hypothesis (esSub : es `<=` lfsp_eventset p).
@@ -283,15 +283,15 @@ Module Export lFsPosetLTS.
 
 Module Export Def.
 Section Def.  
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (l : L) (es : {fset E}).
-Implicit Types (p : lfsposet E L bot).
+Implicit Types (p : lfsposet E L).
 
-Definition lfsp_add_event l es p : lfsposet E L bot :=
+Definition lfsp_add_event l es p : lfsposet E L :=
   let e := lfsp_fresh p in
   let q := lfspre_add_event l es p in
   match (l != bot) && (es `<=` (lfsp_eventset p)) =P true with
-  | ReflectF _  => lFsPoset.empty E L bot
+  | ReflectF _  => lFsPoset.empty E L
   | ReflectT pf => mklFsPoset
     (let: conj lD esSub := andP pf in
     let supcl := add_event_supp_closed lD esSub (lfsp_supp_closed p) in
@@ -308,9 +308,9 @@ End Def.
 (* TODO: there is a lot of copypaste from lFsPrePosetLTS ... *)
 Module LTS.
 Section LTS.
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (l : L) (es : {fset E}).
-Implicit Types (p : lfsposet E L bot).
+Implicit Types (p : lfsposet E L).
 
 Definition ltrans l p q := 
   (l != bot) &&
@@ -333,14 +333,14 @@ Proof.
 Qed.
   
 Definition mixin := 
-  let S := lfsposet E L bot in
+  let S := lfsposet E L in
   @LTS.LTS.Mixin S L _ _ _ enabledP. 
 Definition ltsType := 
-  Eval hnf in let S := lfsposet E L bot in (LTSType S L mixin).
+  Eval hnf in let S := lfsposet E L in (LTSType S L mixin).
 
 End LTS.
 
-Arguments ltsType E L bot : clear implicits.
+Arguments ltsType E L : clear implicits.
 
 Module Export Exports.
 Canonical ltsType.
@@ -352,10 +352,10 @@ Export LTS.Exports.
 
 Module Export Theory.
 Section Theory.  
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (l : L) (es : {fset E}).
-Implicit Types (p q : lfsposet E L bot).
-Implicit Types (tr : trace (LTS.ltsType E L bot)).
+Implicit Types (p q : lfsposet E L).
+Implicit Types (tr : trace (LTS.ltsType E L)).
 
 Import lPoset.Syntax.
 Local Open Scope lts_scope.
@@ -469,9 +469,9 @@ Proof.
     rewrite upd_iso_delta_eq /lfsp_fresh //; last exact/fresh_seq_nmem.
     case: ifP=> // _; exact/labg.
   - rewrite !fs_caE !lfsp_add_eventE // => in1 in2.
-    rewrite -fs_caE (@emb_fs_ca _ _ _ _ _ p q _ _ injg) //.
+    rewrite -fs_caE (@emb_fs_ca _ _ _ _ p q _ _ injg) //.
     rewrite upd_iso_delta_eq //; last exact/fresh_seq_nmem.
-    by rewrite -(@emb_dw_clos _ _ _ _ g p q) //.
+    by rewrite -(@emb_dw_clos _ _ _ g p q) //.
   case bijf=> h K K'.  
   exists [eta h with lfsp_fresh q |-> lfsp_fresh p] => e.
   all: rewrite lfsp_add_eventE // !in_fset1U /=; case: ifP=> //= [+ _|?]. 
@@ -488,7 +488,7 @@ Qed.
 Hint Resolve lfsp_supp_closed lfsp_acyclic : core.
 
 Lemma invariant_operational : 
-  @invariant L (LTS.ltsType E L bot) (@operational _ _ _).
+  @invariant L (LTS.ltsType E L) (@operational _ _).
 Proof.
   move=> p q [l /lfsp_ltransP[? [? /[dup] ? /fsubsetP sub ->]]].
   move/operationalP=> o; apply/operationalP=>> //.
@@ -501,7 +501,7 @@ Qed.
 (* TODO: invariant_conseq_num ? *)
 
 Lemma lfsp_trace_fresh tr p:
-  let emp := lFsPoset.empty E L bot in
+  let emp := lFsPoset.empty E L in
   p = lst_state emp tr ->
   tr \in trace_lang emp -> lfsp_fresh p = iter (size tr) fresh \i0.
 Proof.
@@ -520,7 +520,7 @@ Proof.
 Qed. 
 
 Lemma lfsp_trace_eventset tr :
-  let emp := lFsPoset.empty E L bot in
+  let emp := lFsPoset.empty E L in
   let p := lst_state emp tr in
   tr \in trace_lang emp -> lfsp_eventset p = [fset e | e in nfresh \i0 (size tr)].
 Proof.
@@ -545,7 +545,7 @@ Proof.
 Qed. 
 
 Lemma lfsp_trace_lab tr e : 
-  let emp := lFsPoset.empty E L bot in 
+  let emp := lFsPoset.empty E L in 
   let p := lst_state emp tr in
   tr \in trace_lang emp -> fs_lab p e = nth bot (map lbl tr) (encode e).
 Proof.
@@ -571,12 +571,12 @@ Proof.
 Qed.
 
 Lemma lfsp_lang_lin tr : 
-  let emp := lFsPoset.empty E L bot in 
+  let emp := lFsPoset.empty E L in 
   let p := lst_state emp tr in
   tr \in trace_lang emp -> labels tr \in lin p.
 Proof. 
   move=> emp p inTr; rewrite /lin inE /=.
-  pose q := lFsPoset.of_seq E L bot (map lbl tr).
+  pose q := lFsPoset.of_seq E L (map lbl tr).
   have labsD : bot \notin (map lbl tr).
   - apply/mapP=> -[[/=> /(allP (trace_steps _))/[swap]<-]].
     by case/lfsp_ltransP=> /eqP.
@@ -600,7 +600,7 @@ Proof.
 Qed.
 
 Lemma lfsp_lin_trace_lang tr : 
-  let emp := lFsPoset.empty E L bot in 
+  let emp := lFsPoset.empty E L in 
   let p := lst_state emp tr in
   labels tr \in lin p -> tr \in trace_lang emp.
 Proof.
@@ -609,7 +609,7 @@ Proof.
   rewrite lfsp_trace_labels_defined.  
   move=> sizeE; apply/eqP/esym/val_inj. 
   apply/lFsPrePoset.size0_empty => //=. 
-  set f := [eta (@lfsp_size E L bot)]: lfsposet _ _ _ -> nat.
+  set f := [eta (@lfsp_size E L)]: lfsposet _ _ -> nat.
   move: (@measure_lst _ _ _ f S) sizeE=> /=; rewrite /f /= /==> -> //.
   - rewrite iter_succn; lia.
   move=> s s' l; case/lfsp_ltransP=> ? [?? ->]. 
@@ -619,7 +619,7 @@ Qed.
 Lemma max_of_seq (ls : seq L): 
   bot \notin ls ->
   (if ls == [::] then fset0 else [fset iter (size ls).-1 fresh \i0])
-  `<=` lfsp_eventset (lFsPoset.of_seq E L bot ls).
+  `<=` lfsp_eventset (lFsPoset.of_seq E L ls).
 Proof.
   move=> labsD.
   rewrite /= lFsPoset.of_seq_valE labsD //. 
@@ -631,11 +631,11 @@ Qed.
 Lemma of_seq_rcons l ls: 
   bot \notin ls ->
   l != bot ->
-  lFsPoset.of_seq E L bot (rcons ls l) = 
+  lFsPoset.of_seq E L (rcons ls l) = 
   lfsp_add_event 
     l
     (if ls == [::] then fset0 else [fset iter (size ls).-1 fresh \i0])
-    (lFsPoset.of_seq E L bot ls).
+    (lFsPoset.of_seq E L ls).
 Proof.
   move=> nls nl; apply/eqP/lfspreposet_eqP.
   have labsDr: bot \notin rcons ls l. 
@@ -662,7 +662,7 @@ Proof.
 Qed.
 
 Lemma operational_of_seq ls : 
-  bot \notin ls -> operational (lFsPoset.of_seq E L bot ls).
+  bot \notin ls -> operational (lFsPoset.of_seq E L ls).
 Proof.
   move=> labsD; apply/operationalP=>>.
   rewrite lFsPoset.of_seq_caE labsD //.
@@ -670,7 +670,7 @@ Proof.
 Qed.
 
 Section BackwardStep.
-Context (p : lfsposet E L bot) (n : nat).
+Context (p : lfsposet E L) (n : nat).
 Hypothesis oper : operational p.
 Hypothesis fs_p : lfsp_eventset p = [fset e | e in nfresh \i0 n].
 Hypothesis ne0n : n != 0%N.
@@ -735,9 +735,9 @@ Qed.
 End BackwardStep.
 
 Lemma lfsp_lin_lang p (ls : seq L) : 
-  let emp := lFsPoset.empty E L bot in 
+  let emp := lFsPoset.empty E L in 
   bot \notin ls ->
-  is_hom id p (lFsPoset.of_seq E L bot ls) ->
+  is_hom id p (lFsPoset.of_seq E L ls) ->
   exists2 tr : trace _,
       lst_state emp tr = p & 
       labels tr = ls.
@@ -768,16 +768,16 @@ Proof.
   rewrite of_seq_rcons // => homf.
   have?: 
     (if ls == [::] then fset0 else [fset iter (size ls).-1 fresh \i0])
-    `<=` lfsp_eventset (lFsPoset.of_seq E L bot ls).
+    `<=` lfsp_eventset (lFsPoset.of_seq E L ls).
   - exact/max_of_seq.
   move: (str); case/lfsp_ltransP=> ?[es ?/[dup] pE->].
   move: homf=> /[dup] homf /is_hom_id_finsuppE.
   rewrite pE ?lfsp_add_eventE // => fE.
-  have fqE: lfsp_fresh (lFsPoset.of_seq E L bot ls) = lfsp_fresh q.
+  have fqE: lfsp_fresh (lFsPoset.of_seq E L ls) = lfsp_fresh q.
   - apply/(@is_sup_uniq _ _ (lfsp_fresh q |` lfsp_eventset q)).
     + rewrite fE; exact/is_sup_fresh.
     exact/is_sup_fresh.
-  have fsE: lfsp_eventset q = lfsp_eventset (lFsPoset.of_seq E L bot ls).
+  have fsE: lfsp_eventset q = lfsp_eventset (lFsPoset.of_seq E L ls).
   - apply/fsetP=> x; move/fsetP/(_ x): fE; rewrite !in_fset1U fqE.
     case: (x =P _)=> //->_; by rewrite -{2}fqE ?(negbTE (fresh_seq_nmem _)).
   case: (IHl q)=> //.
@@ -809,11 +809,11 @@ Module Export PomsetLTS.
 (* TODO: there is a lot of copypaste from lFsPrePosetLTS ... *)
 Module LTS.
 Section LTS.
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (l : L) (es : {fset E}).
-Implicit Types (p q : pomset E L bot).
+Implicit Types (p q : pomset E L).
 
-Definition ltrans l (p q : lfsposet E L bot) := 
+Definition ltrans l (p q : lfsposet E L) := 
   (l != bot) &&
   [exists es : fpowerset (lfsp_eventset p),
     iso_eqv q (lfsp_add_event l (val es) p) 
@@ -854,14 +854,14 @@ Proof.
 Qed.
   
 Definition mixin := 
-  let S := pomset E L bot in
+  let S := pomset E L in
   @LTS.LTS.Mixin S L _ _ _ enabledP. 
 Definition pomltsType := 
-  Eval hnf in let S := pomset E L bot in (LTSType S L mixin).
+  Eval hnf in let S := pomset E L in (LTSType S L mixin).
 
 End LTS.
 
-Arguments pomltsType E L bot : clear implicits.
+Arguments pomltsType E L : clear implicits.
 
 Module Export Exports.
 Canonical pomltsType.
@@ -874,10 +874,10 @@ Export LTS.Exports.
 
 Module Export Theory.
 Section Theory.  
-Context (E : identType) (L : choiceType) (bot : L).
+Context (E : identType) (L : botType).
 Implicit Types (l : L) (es : {fset E}).
-Implicit Types (p q : pomset E L bot).
-Implicit Types (tr : trace (LTS.pomltsType E L bot)).
+Implicit Types (p q : pomset E L).
+Implicit Types (tr : trace (LTS.pomltsType E L)).
 
 Import lPoset.Syntax.
 Local Open Scope lts_scope.
@@ -885,10 +885,10 @@ Local Open Scope lts_scope.
 Export Simulation.Exports.
 Import Simulation.Syntax.
 
-Definition R : hrel (pomset E L bot) (lfsposet E L bot) := 
+Definition R : hrel (pomset E L) (lfsposet E L) := 
   iso_eqv.
 
-Lemma ltransP l (p q : lfsposet E L bot) :
+Lemma ltransP l (p q : lfsposet E L) :
   reflect (l != bot /\ exists2 es, 
              es `<=` lfsp_eventset p & 
              iso_eqv q (lfsp_add_event l es p))
@@ -906,7 +906,7 @@ Qed.
 
 
 Lemma iso_sim_class_of : Simulation.class_of 
-  (iso_eqv : hrel (pomset E L bot) (lfsposet E L bot)).
+  (iso_eqv : hrel (pomset E L) (lfsposet E L)).
 Proof.
   do ? split; rewrite /ltrans /==> l s1 t1 t2 ?.
   case/lfsp_ltransP=> ? [es ? t2E].
@@ -919,7 +919,7 @@ Qed.
 Definition iso_sim := Simulation.Pack iso_sim_class_of.
 
 Lemma iso_sim_tr_class_of : Simulation.class_of 
-  (iso_eqv : hrel (lfsposet E L bot) (pomset E L bot)).
+  (iso_eqv : hrel (lfsposet E L) (pomset E L)).
 Proof.
   do ? split; rewrite /ltrans /==> l s1 t1 t2.
   rewrite iso_eqv_sym -eqquot_piE=> /eqP->.
@@ -930,10 +930,10 @@ Qed.
 
 Definition iso_sim_tr := Simulation.Pack iso_sim_tr_class_of.
 
-Notation of_seq := (lFsPoset.of_seq E L bot).
+Notation of_seq := (lFsPoset.of_seq E L).
 
 Lemma pomset_linP p (ls : seq L) :
-  let emp := lFsPoset.empty E L bot in 
+  let emp := lFsPoset.empty E L in 
   bot \notin ls ->
     reflect 
       (exists tr : trace _,

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -594,7 +594,7 @@ Proof.
   move: (lfsp_acyclic p)=> acyc.
   move=> e1In e2In Hca.
   apply/orP; right; apply/and3P; split=> //.
-  apply/(fs_ca_ident_le supcl acyc)=> //.
+  apply/operationalP; last exact/Hca.
   apply/(invariant_trace_lang invariant_operational)=> //. 
   exact/lFsPrePoset.empty_operational.
 Qed.
@@ -665,8 +665,6 @@ Lemma operational_of_seq ls :
   bot \notin ls -> operational (lFsPoset.of_seq E L bot ls).
 Proof.
   move=> labsD; apply/operationalP=>>.
-  - exact/lfsp_supp_closed.
-  - exact/lfsp_acyclic.
   rewrite lFsPoset.of_seq_caE labsD //.
   by case/orP=> [/eqP->|/andP[->]].
 Qed.
@@ -684,7 +682,7 @@ Lemma emax : [forall y : lfsp_eventset p, ~~ fs_ica p e (val y)].
 Proof.
   apply/forallP=> -[]/= f. 
   rewrite fs_p ?inE /==> ?; apply/negP.
-  move/(operational_sca (lfsp_supp_closed _) (lfsp_acyclic _)): oper.
+  move/operational_scaP: oper.
   move/[swap]/(@t_step E (fs_ica p)).
   move/(fs_scaP _ _ (lfsp_supp_closed _) (lfsp_acyclic _)).
   move/[swap]/[apply]; ilia.

--- a/theories/concur/pomset_lts.v
+++ b/theories/concur/pomset_lts.v
@@ -607,7 +607,8 @@ Proof.
   move=> /=; rewrite /trace_lang ?/(_ \in _) /= /lin /=.
   move/bhom_le_size; rewrite lFsPoset.of_seq_size size_map.
   rewrite lfsp_trace_labels_defined.  
-  move=> sizeE; apply/eqP/esym/val_inj/lFsPrePoset.empty_eqP=> /=. 
+  move=> sizeE; apply/eqP/esym/val_inj. 
+  apply/lFsPrePoset.size0_empty => //=. 
   set f := [eta (@lfsp_size E L bot)]: lfsposet _ _ _ -> nat.
   move: (@measure_lst _ _ _ f S) sizeE=> /=; rewrite /f /= /==> -> //.
   - rewrite iter_succn; lia.
@@ -636,7 +637,7 @@ Lemma of_seq_rcons l ls:
     (if ls == [::] then fset0 else [fset iter (size ls).-1 fresh \i0])
     (lFsPoset.of_seq E L bot ls).
 Proof.
-  move=> nls nl; apply/eqP/lfsposet_eqP.
+  move=> nls nl; apply/eqP/lfspreposet_eqP.
   have labsDr: bot \notin rcons ls l. 
   - by rewrite mem_rcons ?inE negb_or eq_sym nls nl.
   have labsD: bot \notin ls. 
@@ -745,7 +746,8 @@ Lemma lfsp_lin_lang p (ls : seq L) :
 Proof.
   elim/last_ind: ls p=>/=.    
   - move=> ? _ homf; exists [trace] => //=.
-    apply/esym/val_inj/lFsPrePoset.empty_eqP. 
+    apply/esym/val_inj/lFsPrePoset.size0_empty. 
+    + exact/lfsp_supp_closed.
     rewrite /lfsp_size (is_hom_id_finsuppE homf).
     rewrite lFsPoset.of_seq_valE //.
     by move: lFsPrePoset.of_seq_size; rewrite /lfsp_size=>->.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -334,7 +334,7 @@ Lemma lfsposet_of0 :
   lfsposet_of (fset0 : {fset E}) = lFsPoset.empty E L bot.
 Proof.
   rewrite /lfsposet_of /lfspreposet_of; case: eqP=> // ?.
-  apply/eqP/lfsposet_eqP; split=>>; rewrite /lFsPoset.empty /=.
+  apply/eqP/lfspreposet_eqP; split=>>; rewrite /lFsPoset.empty /=.
   - rewrite lFsPrePoset.fs_lab_empty lFsPrePoset.build_lab /sub_lift.
     by case: insubP.
   rewrite lFsPrePoset.fs_ica_empty lFsPrePoset.build_ica /sub_rel_lift /=.

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -293,14 +293,14 @@ Module Export Lang.
 Section lFsPrePosetOf.
 
 (* TODO: (L bot E) order of arguments contradicts (E L bot) in pomset.v *)
-Context {L : choiceType} {bot : L} {E : eventType L}.
+Context {L : botType} {E : eventType L}.
 Context (X : {fset E}).
 Implicit Types (e : E).
 
 Hypothesis lab_def : [forall x : X, lab (val x) != bot].
 
 Definition lfspreposet_of := 
-  @lFsPrePoset.build_cov E L bot X (lab \o val) (<=%O : rel E).
+  @lFsPrePoset.build_cov E L X (lab \o val) (<=%O : rel E).
 
 Lemma lfspreposet_of_finsupp : 
   lfsp_eventset lfspreposet_of = X.
@@ -321,17 +321,17 @@ Qed.
 End lFsPrePosetOf.
 
 Section lFsPosetOf.
-Context {L : choiceType} {bot : L}.
+Context {L : botType}.
 
-Definition lfsposet_of (E : eventType L) (X : {fset E}) : lfsposet E L bot :=
+Definition lfsposet_of (E : eventType L) (X : {fset E}) : lfsposet E L :=
   if eqP is ReflectT p then
-    mklFsPoset (@lfspreposet_of_mixin L bot E X p)
-  else (lFsPoset.empty E L bot).
+    mklFsPoset (@lfspreposet_of_mixin L E X p)
+  else (lFsPoset.empty E L).
 
 Context (E : eventType L) (X : {fset E}).
 
 Lemma lfsposet_of0 : 
-  lfsposet_of (fset0 : {fset E}) = lFsPoset.empty E L bot.
+  lfsposet_of (fset0 : {fset E}) = lFsPoset.empty E L.
 Proof.
   rewrite /lfsposet_of /lfspreposet_of; case: eqP=> // ?.
   apply/eqP/lfspreposet_eqP; split=>>; rewrite /lFsPoset.empty /=.
@@ -343,13 +343,13 @@ Qed.
 
 Lemma lfsposet_of_emp : 
   [forall x : X, lab (val x) != bot] <> true ->
-  lfsposet_of X = (lFsPoset.empty E L bot).
+  lfsposet_of X = (lFsPoset.empty E L).
 Proof. by rewrite /lfsposet_of; case: eqP. Qed.
 
 Hypothesis lab_def : [forall x : X, lab (val x) != bot].
 
 Lemma lfsposet_of_val : 
-  lfsposet_of X = lfspreposet_of X :> lfspreposet E L bot.
+  lfsposet_of X = lfspreposet_of X :> lfspreposet E L.
 Proof. by rewrite /lfsposet_of; case: eqP=> // *. Qed.
 
 Lemma lfsposet_of_eventset :
@@ -376,15 +376,15 @@ Qed.
 
 End lFsPosetOf.
 
-Lemma lfsposet_of0_eventset {L : choiceType} {bot : L} (E : eventType L) : 
-  lfsp_eventset (@lfsposet_of L bot E (fset0 : {fset E})) = fset0.
+Lemma lfsposet_of0_eventset {L : botType} (E : eventType L) : 
+  lfsp_eventset (@lfsposet_of L E (fset0 : {fset E})) = fset0.
 Proof. 
   rewrite lfsposet_of_val; last (apply/forallP; case)=> //.
   by rewrite lFsPrePoset.build_eventset //; case.  
 Qed.
 
-Definition pomset_lang {L : choiceType} {bot : L} (E : eventType L) := 
-  fun (p : pomset E L bot) => 
+Definition pomset_lang {L : botType} (E : eventType L) := 
+  fun (p : pomset E L) => 
     exists2 X : {fset E}, cfg (mem X) & p = \pi (lfsposet_of X).
 
 End Lang.
@@ -467,7 +467,7 @@ End Build.
 
 Module Export Theory.
 Section Theory. 
-Context {L : choiceType} {E1 E2 : eventType L} (bot : L). 
+Context {L : botType} {E1 E2 : eventType L}.
 Implicit Types (f : {hom E1 -> E2}).
 Implicit Types (X : {fset E1}).
 
@@ -532,15 +532,15 @@ Qed.
 (* TODO: prove first on the level of `lfsposet_of`, 
  *   use subsumption notation
  *)
-Lemma pomset_lang_sub f (p : pomset E1 L bot) :
+Lemma pomset_lang_sub f (p : pomset E1 L) :
   (forall x : E2, lab x != bot) ->
   pomset_lang p -> 
-  exists2 q : pomset E2 L bot, pomset_lang q & bhom_le p q.
+  exists2 q : pomset E2 L, pomset_lang q & bhom_le p q.
 Proof.
   move=> ld2 [X [ccX cfX]].
   case: ([forall x : X, lab (val x) != bot] =P true); first last.
   - move/lfsposet_of_emp=>->->.
-    exists (\pi (lFsPoset.empty E2 L bot)).
+    exists (\pi (lFsPoset.empty E2 L)).
     + exists fset0; first exact/cfg0; by rewrite lfsposet_of0.
     rewrite pom_bhom_le -?lfsposet_of0; apply/lFinPoset.bHom.bhom_leP.
     (* have g: forall E E' : eventType L, *)
@@ -548,25 +548,25 @@ Proof.
     (*         [FinEvent of @lfsposet_of L bot E' fset0]. *)
     have g: forall E E' : eventType L,
             (* TODO: make arguments of (@lfsposet_of L bot E) implicit *)
-            (lfsp_eventset (@lfsposet_of L bot E  (fset0 : {fset E}))) ->
-            (lfsp_eventset (@lfsposet_of L bot E' (fset0 : {fset E'}))) .
+            (lfsp_eventset (@lfsposet_of L E  (fset0 : {fset E}))) ->
+            (lfsp_eventset (@lfsposet_of L E' (fset0 : {fset E'}))) .
     + by move=> ??; rewrite ?lfsposet_of0_eventset=> [[]].
     exists=> /=; exists (g E2 E1); do ? split=> /=.
     1,2: by move=> /[dup]; rewrite {1}lfsposet_of0_eventset=> [[]].
     by exists (g E1 E2)=> /[dup] /=; rewrite {1}lfsposet_of0_eventset=> [[]].
-  move=> ld1 pE; exists (\pi (@lfsposet_of L bot E2 (f @` X))).
+  move=> ld1 pE; exists (\pi (@lfsposet_of L E2 (f @` X))).
   - exists (f @` X)=> //; split; last exact/cf_free_fset/cons_mon/cfX.
     move=>> /[swap]/imfsetP[] /= x' /[swap]-> /[swap] /hom_prefix.
     case=> y' -> /ccX/[apply] ?; by apply/imfsetP; exists y'.
   rewrite pE pom_bhom_le.
   have ?: [forall x : (f @` X), lab (val x) != bot] by exact/forallP.
-  have In: forall x : (lfsp_eventset (@lfsposet_of L bot E1 X)),
-    f (val x) \in (lfsp_eventset (@lfsposet_of L bot E2 (f @` X))).
+  have In: forall x : (lfsp_eventset (@lfsposet_of L E1 X)),
+    f (val x) \in (lfsp_eventset (@lfsposet_of L E2 (f @` X))).
   - case=> /= x; rewrite ?lfsposet_of_eventset //. 
     by move=> ?; rewrite in_imfset.
   set g : 
-    [FinEvent of (@lfsposet_of L bot E1 X)] -> 
-    [FinEvent of (@lfsposet_of L bot E2 (f @` X))] := fun x => [` (In x)].
+    [FinEvent of (@lfsposet_of L E1 X)] -> 
+    [FinEvent of (@lfsposet_of L E2 (f @` X))] := fun x => [` (In x)].
   (* TODO: use bhom_leP lemma? *)
   apply/lFinPoset.bHom.bhom_leP; exists=> /=. 
   have bijg : bijective g.
@@ -580,7 +580,7 @@ Proof.
   - case=> /= e /[dup]; rewrite {1}lfsposet_of_eventset // => ef ein.
     rewrite /g !fin_labE -?fin_lab_mono.
     move: ef=> /imfsetP[e'] /= ein' eqe'. 
-    have ein'': e' \in lfsp_eventset (lfsposet_of X : lfsposet E1 L bot).
+    have ein'': e' \in lfsp_eventset (lfsposet_of X : lfsposet E1 L).
     + by rewrite @lfsposet_of_eventset.
     have->: [` ein] = g [` ein''].
     + by rewrite /g; apply/val_inj. 

--- a/theories/concur/prime_eventstruct.v
+++ b/theories/concur/prime_eventstruct.v
@@ -303,16 +303,13 @@ Definition lfspreposet_of :=
   @lFsPrePoset.build_cov E L bot X (lab \o val) (<=%O : rel E).
 
 Lemma lfspreposet_of_finsupp : 
-  finsupp lfspreposet_of = X.
-Proof. exact/lFsPrePoset.build_finsupp/forallP. Qed.
+  lfsp_eventset lfspreposet_of = X.
+Proof. exact/lFsPrePoset.build_eventset/forallP. Qed.
 
 Lemma lfspreposet_of_mixin :
-  [&& lab_defined lfspreposet_of,
-      supp_closed lfspreposet_of &
-      acyclic (fin_ica lfspreposet_of)].
+  supp_closed lfspreposet_of && acyclic (fin_ica lfspreposet_of).
 Proof.
-  apply/and3P; split.
-  - by apply/lFsPrePoset.lab_defined_build/forallP.
+  apply/andP; split.
   - by apply/lFsPrePoset.supp_closed_build/forallP.
   apply/lFsPrePoset.build_cov_acyclic; last first.
   - move=> /=; exact/le_trans.
@@ -355,8 +352,8 @@ Lemma lfsposet_of_val :
   lfsposet_of X = lfspreposet_of X :> lfspreposet E L bot.
 Proof. by rewrite /lfsposet_of; case: eqP=> // *. Qed.
 
-Lemma lfsposet_of_finsupp :
-  finsupp (lfsposet_of X) = X.
+Lemma lfsposet_of_eventset :
+  lfsp_eventset (lfsposet_of X) = X.
 Proof. by rewrite lfsposet_of_val lfspreposet_of_finsupp. Qed.
 
 Lemma lfsposet_of_lab :
@@ -379,11 +376,11 @@ Qed.
 
 End lFsPosetOf.
 
-Lemma lfsposet_of0_finsupp {L : choiceType} {bot : L} (E : eventType L) : 
-  finsupp (@lfsposet_of L bot E (fset0 : {fset E})) = fset0.
+Lemma lfsposet_of0_eventset {L : choiceType} {bot : L} (E : eventType L) : 
+  lfsp_eventset (@lfsposet_of L bot E (fset0 : {fset E})) = fset0.
 Proof. 
   rewrite lfsposet_of_val; last (apply/forallP; case)=> //.
-  by rewrite lFsPrePoset.build_finsupp //; case.  
+  by rewrite lFsPrePoset.build_eventset //; case.  
 Qed.
 
 Definition pomset_lang {L : choiceType} {bot : L} (E : eventType L) := 
@@ -551,22 +548,22 @@ Proof.
     (*         [FinEvent of @lfsposet_of L bot E' fset0]. *)
     have g: forall E E' : eventType L,
             (* TODO: make arguments of (@lfsposet_of L bot E) implicit *)
-            (finsupp (@lfsposet_of L bot E  (fset0 : {fset E}))) ->
-            (finsupp (@lfsposet_of L bot E' (fset0 : {fset E'}))) .
-    + by move=> ??; rewrite ?lfsposet_of0_finsupp=> [[]].
+            (lfsp_eventset (@lfsposet_of L bot E  (fset0 : {fset E}))) ->
+            (lfsp_eventset (@lfsposet_of L bot E' (fset0 : {fset E'}))) .
+    + by move=> ??; rewrite ?lfsposet_of0_eventset=> [[]].
     exists=> /=; exists (g E2 E1); do ? split=> /=.
-    1,2: by move=> /[dup]; rewrite {1}lfsposet_of0_finsupp=> [[]].
-    by exists (g E1 E2)=> /[dup] /=; rewrite {1}lfsposet_of0_finsupp=> [[]].
+    1,2: by move=> /[dup]; rewrite {1}lfsposet_of0_eventset=> [[]].
+    by exists (g E1 E2)=> /[dup] /=; rewrite {1}lfsposet_of0_eventset=> [[]].
   move=> ld1 pE; exists (\pi (@lfsposet_of L bot E2 (f @` X))).
   - exists (f @` X)=> //; split; last exact/cf_free_fset/cons_mon/cfX.
     move=>> /[swap]/imfsetP[] /= x' /[swap]-> /[swap] /hom_prefix.
     case=> y' -> /ccX/[apply] ?; by apply/imfsetP; exists y'.
   rewrite pE pom_bhom_le.
   have ?: [forall x : (f @` X), lab (val x) != bot] by exact/forallP.
-  have In: forall x : (finsupp (@lfsposet_of L bot E1 X)),
-    f (val x) \in (finsupp (@lfsposet_of L bot E2 (f @` X))).
-  - case=> /= x; rewrite ?lfsposet_of_finsupp //. 
-    move=> ?; by rewrite in_imfset.
+  have In: forall x : (lfsp_eventset (@lfsposet_of L bot E1 X)),
+    f (val x) \in (lfsp_eventset (@lfsposet_of L bot E2 (f @` X))).
+  - case=> /= x; rewrite ?lfsposet_of_eventset //. 
+    by move=> ?; rewrite in_imfset.
   set g : 
     [FinEvent of (@lfsposet_of L bot E1 X)] -> 
     [FinEvent of (@lfsposet_of L bot E2 (f @` X))] := fun x => [` (In x)].
@@ -574,24 +571,24 @@ Proof.
   apply/lFinPoset.bHom.bhom_leP; exists=> /=. 
   have bijg : bijective g.
   - apply/inj_card_bij=> /=; last first.
-    + rewrite -?cardfE !lfsposet_of_finsupp //.
+    + rewrite -?cardfE !lfsposet_of_eventset //.
       exact/(leq_trans (leq_imfset_card _ _ _)).
     rewrite /g; case=> ? in1 [? in2 /=] /(congr1 val) /= /hom_cons_inj.
     move/(_ _ _ in1 in2)=> ev; apply/val_inj/ev/cfX=> ?.
-    by rewrite lfsposet_of_finsupp.
+    by rewrite lfsposet_of_eventset.
   exists (invFh bijg); split=> //; last exact/injFh_bij. 
-  - case=> /= e /[dup]; rewrite {1}lfsposet_of_finsupp // => ef ein.
+  - case=> /= e /[dup]; rewrite {1}lfsposet_of_eventset // => ef ein.
     rewrite /g !fin_labE -?fin_lab_mono.
     move: ef=> /imfsetP[e'] /= ein' eqe'. 
-    have ein'': e' \in finsupp (lfsposet_of X : lfsposet E1 L bot).
-    + by rewrite @lfsposet_of_finsupp.
+    have ein'': e' \in lfsp_eventset (lfsposet_of X : lfsposet E1 L bot).
+    + by rewrite @lfsposet_of_eventset.
     have->: [` ein] = g [` ein''].
     + by rewrite /g; apply/val_inj. 
     rewrite invFh_f /= !lfsposet_of_lab ?eqe' ?lab_preserving //.
     by apply/imfsetP; exists e'.
   apply/(cancel_le_ahomo_homo (f_invFh _)). 
   case=> ? /[dup] + ? [? /[dup]+?]. 
-  rewrite {1 2}lfsposet_of_finsupp // => ??.
+  rewrite {1 2}lfsposet_of_eventset // => ??.
   rewrite /g ?/(_ <= _) /=.
   rewrite !lfsposet_of_fin_ca //.
   move=> /(@in_cons_ca_anti f X). 

--- a/theories/lang/regmachine.v
+++ b/theories/lang/regmachine.v
@@ -55,7 +55,7 @@ Open Scope exec_eventstruct_scope.
 
 Import Label.Syntax.
 
-Context {E : identType} {Val : inhType}.
+Context {E : identType} {dV : unit} {Val : inhType dV}.
 
 (*Notation n := (@n val).*)
 (*Notation porf_event_struct := (porf_eventstruct E Val).


### PR DESCRIPTION
1) Use `lfsp_eventset` instead of `finsupp` to get a set of events of a pomset
2) Use `L : botType`  as a type of labels, avoid passing `bot` value explicitly